### PR TITLE
feat: Add message usage helper classes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_NAME;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_NUSNET;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_PHONE;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -21,22 +22,16 @@ public class AddPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "addstu";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
-            + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_NUSNET + "NUSNET "
-            + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_NUSNET + "e0123456 "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+    public static final String MESSAGE_USAGE = generateMessageUsage(
+            COMMAND_WORD,
+            "Adds a person to the address book. ",
+            PARAMETER_NAME,
+            PARAMETER_PHONE,
+            PARAMETER_EMAIL,
+            PARAMETER_NUSNET,
+            PARAMETER_ADDRESS,
+            PARAMETER_TAG.asMultiple(2)
+    );
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_NAME;

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_INDEX;
 
 import java.util.List;
 
@@ -18,10 +20,11 @@ public class DeletePersonCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+    public static final String MESSAGE_USAGE = generateMessageUsage(
+            COMMAND_WORD,
+            "Deletes the person identified by the index number used in the displayed person list.",
+            PARAMETER_INDEX
+    );
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_INDEX;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_INDEX;

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -1,12 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_INDEX;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_NAME;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_NUSNET;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_PHONE;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -37,20 +39,19 @@ public class EditPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_NUSNET + "NUSNET] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_NUSNET + "e0123456 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+    public static final String MESSAGE_USAGE = generateMessageUsage(
+            COMMAND_WORD,
+            "Edits the details of the person identified "
+                    + "by the index number used in the displayed person list. "
+                    + "Existing values will be overwritten by the input values.",
+            PARAMETER_INDEX,
+            PARAMETER_NAME.asOptional(false),
+            PARAMETER_PHONE.asOptional(true),
+            PARAMETER_EMAIL.asOptional(true),
+            PARAMETER_NUSNET.asOptional(true),
+            PARAMETER_ADDRESS.asOptional(false),
+            PARAMETER_TAG.asMultiple(0)
+    );
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -21,7 +21,7 @@ public class FindPersonCommand extends Command {
             "Finds all persons whose names contain any of "
                     + "the specified keywords (case-insensitive) and displays them as a list with index numbers.",
             "KEYWORD [MORE_KEYWORDS]...",
-            COMMAND_WORD + "alice bob charlie"
+            COMMAND_WORD + " alice bob charlie"
 
     );
 

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -9,16 +10,20 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = generateMessageUsage(
+            COMMAND_WORD,
+            "Finds all persons whose names contain any of "
+                    + "the specified keywords (case-insensitive) and displays them as a list with index numbers.",
+            "KEYWORD [MORE_KEYWORDS]...",
+            COMMAND_WORD + "alice bob charlie"
+
+    );
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+
 import seedu.address.model.Model;
 
 /**
@@ -9,8 +11,11 @@ public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = generateMessageUsage(
+            COMMAND_WORD,
+            "Shows program usage instructions.",
+            COMMAND_WORD
+    );
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.util.CommandUtil.generateMessageUsage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 
 import seedu.address.model.Model;
 

--- a/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands.util;
 
 /**
  * A container for {@code Command} specific utility functions.
+ * <p>
+ *
  */
-public class CommandUtil {
+public class CommandMessageUsageUtil {
     /**
      * Generates the message usage, given the {@code commandWord}, {@code description},
      * and {@code example} as strings.
@@ -49,7 +51,7 @@ public class CommandUtil {
 
         for (Parameter p : parameters) {
             stringBuilder
-                    .append(p.getParameterDetails())
+                    .append(p.getFormattedParameterDetails())
                     .append(" ");
         }
 

--- a/src/main/java/seedu/address/logic/commands/util/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandUtil.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands.util;
+
+/**
+ * A container for {@code Command} specific utility functions.
+ */
+public class CommandUtil {
+    /**
+     * Generates the message usage, given the {@code commandWord}, {@code description},
+     * and {@code example} as strings.
+     */
+    public static String generateMessageUsage(String commandWord, String description,
+                                              String example) {
+        return commandWord + ": "
+                + description + "\n"
+                + "Example: " + example;
+    }
+
+    /**
+     * Generates the message usage, given the {@code commandWord}, {@code description},
+     * {@code parameters}, and {@code example} as strings.
+     */
+    public static String generateMessageUsage(String commandWord, String description,
+                                              String parameters, String example) {
+        return commandWord + ": "
+                + description + "\n"
+                + "Parameters: " + parameters + "\n"
+                + "Example: " + example;
+    }
+
+    /**
+     * Generates the message usage, given the {@code commandWord}, {@code description} as strings,
+     * and the {@code parameters}.
+     */
+    public static String generateMessageUsage(String commandWord, String description,
+                                              Parameter... parameters) {
+        return generateMessageUsage(
+                commandWord,
+                description,
+                generateMessageUsageParameters(parameters),
+                generateMessageUsageExample(commandWord, parameters)
+        );
+    }
+
+    /**
+     * Generates the message usage parameters, given the {@code parameters}.
+     */
+    public static String generateMessageUsageParameters(Parameter... parameters) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (Parameter p : parameters) {
+            stringBuilder
+                    .append(p.getParameterDetails())
+                    .append(" ");
+        }
+
+        return stringBuilder.toString().trim();
+    }
+
+    /**
+     * Generates the message usage example, given the {@code commmandWord} and {@code parameters}.
+     */
+    public static String generateMessageUsageExample(String commandWord, Parameter... parameters) {
+        StringBuilder stringBuilder = new StringBuilder(commandWord + " ");
+
+        for (Parameter p : parameters) {
+            stringBuilder
+                    .append(p.getParameterWithExampleValues())
+                    .append(" ");
+        }
+
+        return stringBuilder.toString().trim();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
@@ -6,6 +6,8 @@ import seedu.address.logic.parser.Prefix;
  * A defined parameter is a {@code Parameter} that has a {@code Prefix}, a name, a hint and an example values,
  * which is used to generate a {@code Command}'s {@code MESSAGE_USAGE},
  * in a more standardized way.
+ * <p>
+ * The key difference from {@code Parameter} is that {@code DefinedParameter} has a prefix.
  *
  * @see Parameter
  */
@@ -24,10 +26,11 @@ public class DefinedParameter extends Parameter {
     }
 
     /**
-     * Constructor for a defined parameter that takes a {@code DefinedParameter}.
+     * Constructor for a defined parameter that takes a {@code DefinedParameter},
+     * {@code detailWrapper}, and {@code exampleRepetitions}.
      */
-    public DefinedParameter(DefinedParameter definedParameter) {
-        super(definedParameter);
+    public DefinedParameter(DefinedParameter definedParameter, String detailWrapper, int exampleRepetitions) {
+        super(definedParameter, detailWrapper, exampleRepetitions);
         this.prefix = definedParameter.prefix;
     }
 
@@ -50,12 +53,13 @@ public class DefinedParameter extends Parameter {
      *
      * @param isExamplePresent Whether the example value should be present.
      */
+    @Override
     public DefinedParameter asOptional(boolean isExamplePresent) {
-        return new DefinedParameterWrapper(this, "[%s]", (isExamplePresent) ? 1 : 0);
+        return new DefinedParameter(this, "[%s]", (isExamplePresent) ? 1 : 0);
     }
 
     /**
-     * Gets the {@code DefinedParameter} as multiple defined parameters.
+     * Gets the {@code DefinedParameter} as a multiple defined parameter.
      * <p>
      * A multiple defined parameter is a {@code DefinedParameter} that is can be used multiple times,
      * including zero times.
@@ -64,50 +68,9 @@ public class DefinedParameter extends Parameter {
      *
      * @param exampleRepetitions The number of times the example values should repeat.
      */
+    @Override
     public DefinedParameter asMultiple(int exampleRepetitions) {
         assert exampleRepetitions >= 0;
-        return new DefinedParameterWrapper(this, "[%s]...", exampleRepetitions);
-    }
-
-    /**
-     * An inner class as a {@code DefinedParameter} wrapper that formats the {@code getParameterDetails}
-     * and {@code getParameterWithExampleValues} nicely within a wrapping context string.
-     */
-    private class DefinedParameterWrapper extends DefinedParameter {
-        private final String wrapper;
-        private int exampleRepetitions;
-
-        public DefinedParameterWrapper(DefinedParameter definedParameter, String wrapper) {
-            super(definedParameter);
-
-            assert wrapper.contains("%s");
-            this.wrapper = wrapper;
-            this.exampleRepetitions = 1;
-        }
-
-        public DefinedParameterWrapper(DefinedParameter definedParameter, String wrapper, int exampleRepetitions) {
-            this(definedParameter, wrapper);
-
-            assert exampleRepetitions >= 0;
-            this.exampleRepetitions = exampleRepetitions;
-        }
-
-        @Override
-        public String getParameterDetails() {
-            return String.format(wrapper, super.getParameterDetails());
-        }
-
-        @Override
-        public String getParameterWithExampleValues() {
-            StringBuilder exampleBuilder = new StringBuilder();
-
-            for (int i = 0; i < exampleRepetitions; i++) {
-                exampleBuilder
-                        .append(getParameterExampleValue(i))
-                        .append(" ");
-            }
-
-            return exampleBuilder.toString().trim();
-        }
+        return new DefinedParameter(this, "[%s]...", exampleRepetitions);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
@@ -36,12 +36,7 @@ public class DefinedParameter extends Parameter {
 
     @Override
     public String getParameterDetails() {
-        return prefix.getPrefix() + super.getParameterDetails();
-    }
-
-    @Override
-    public String getParameterWithExampleValue(int idx) {
-        return prefix.getPrefix() + super.getParameterWithExampleValue(idx);
+        return (prefix.getPrefix() + super.getParameterDetails()).trim();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.commands.util;
+
+import seedu.address.logic.parser.Prefix;
+
+/**
+ * A defined parameter is a {@code Parameter} that has a {@code Prefix}, a name, a hint and an example values,
+ * which is used to generate a {@code Command}'s {@code MESSAGE_USAGE},
+ * in a more standardized way.
+ *
+ * @see Parameter
+ */
+public class DefinedParameter extends Parameter {
+    private final Prefix prefix;
+
+    /**
+     * Constructor for a {@code DefinedParameter} that takes in the {@code parameterName}
+     * and valid {@code parameterExampleValues}, with at least one example value.
+     */
+    public DefinedParameter(Prefix prefix, String parameterName, String... parameterExampleValues) {
+        super(parameterName, null, parameterExampleValues);
+
+        assert prefix != null;
+        this.prefix = prefix;
+    }
+
+    /**
+     * Constructor for a defined parameter that takes a {@code DefinedParameter}.
+     */
+    public DefinedParameter(DefinedParameter definedParameter) {
+        super(definedParameter);
+        this.prefix = definedParameter.prefix;
+    }
+
+    @Override
+    public String getParameterDetails() {
+        return prefix.getPrefix() + super.getParameterDetails();
+    }
+
+    @Override
+    public String getParameterWithExampleValue(int idx) {
+        return prefix.getPrefix() + super.getParameterWithExampleValue(idx);
+    }
+
+    /**
+     * Gets the {@code DefinedParameter} as an optional defined parameter.
+     * <p>
+     * A defined optional parameter is a {@code DefinedParameter} that is optional.
+     * <p>
+     * E.g. '[n/NAME]'
+     *
+     * @param isExamplePresent Whether the example value should be present.
+     */
+    public DefinedParameter asOptional(boolean isExamplePresent) {
+        return new DefinedParameterWrapper(this, "[%s]", (isExamplePresent) ? 1 : 0);
+    }
+
+    /**
+     * Gets the {@code DefinedParameter} as multiple defined parameters.
+     * <p>
+     * A multiple defined parameter is a {@code DefinedParameter} that is can be used multiple times,
+     * including zero times.
+     * <p>
+     * E.g. '[t/TAG]...'
+     *
+     * @param exampleRepetitions The number of times the example values should repeat.
+     */
+    public DefinedParameter asMultiple(int exampleRepetitions) {
+        assert exampleRepetitions >= 0;
+        return new DefinedParameterWrapper(this, "[%s]...", exampleRepetitions);
+    }
+
+    /**
+     * An inner class as a {@code DefinedParameter} wrapper that formats the {@code getParameterDetails}
+     * and {@code getParameterWithExampleValues} nicely within a wrapping context string.
+     */
+    private class DefinedParameterWrapper extends DefinedParameter {
+        private final String wrapper;
+        private int exampleRepetitions;
+
+        public DefinedParameterWrapper(DefinedParameter definedParameter, String wrapper) {
+            super(definedParameter);
+
+            assert wrapper.contains("%s");
+            this.wrapper = wrapper;
+            this.exampleRepetitions = 1;
+        }
+
+        public DefinedParameterWrapper(DefinedParameter definedParameter, String wrapper, int exampleRepetitions) {
+            this(definedParameter, wrapper);
+
+            assert exampleRepetitions >= 0;
+            this.exampleRepetitions = exampleRepetitions;
+        }
+
+        @Override
+        public String getParameterDetails() {
+            return String.format(wrapper, super.getParameterDetails());
+        }
+
+        @Override
+        public String getParameterWithExampleValues() {
+            StringBuilder exampleBuilder = new StringBuilder();
+
+            for (int i = 0; i < exampleRepetitions; i++) {
+                exampleBuilder
+                        .append(getParameterExampleValue(i))
+                        .append(" ");
+            }
+
+            return exampleBuilder.toString().trim();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/util/Parameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/Parameter.java
@@ -70,7 +70,7 @@ public class Parameter {
      * Gets the details of the parameter, which are the parameter name and hint appended behind.
      */
     public String getParameterDetails() {
-        return getParameterName() + " " + getParameterHint();
+        return (getParameterName() + " " + getParameterHint()).trim();
     }
 
     /**
@@ -87,14 +87,6 @@ public class Parameter {
     public String getParameterExampleValue(int idx) {
         assert idx >= 0 && idx < parameterExampleValues.length;
         return parameterExampleValues[idx];
-    }
-
-    /**
-     * Gets the parameter with the parameter example value, at index {@code idx}
-     * from {@code parameterExampleValues}, appended behind.
-     */
-    public String getParameterWithExampleValue(int idx) {
-        return getParameterExampleValue(idx);
     }
 
     /**
@@ -138,5 +130,10 @@ public class Parameter {
     public Parameter asMultiple(int exampleRepetitions) {
         assert exampleRepetitions >= 0;
         return new Parameter(this, "[%s]...", exampleRepetitions);
+    }
+
+    @Override
+    public String toString() {
+        return (getFormattedParameterDetails() + " " + getParameterWithExampleValues()).trim();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/util/Parameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/Parameter.java
@@ -1,0 +1,82 @@
+package seedu.address.logic.commands.util;
+
+import java.util.Optional;
+
+/**
+ * A parameter has a name, a hint, and example values,
+ * which is used to generate a {@code Command}'s {@code MESSAGE_USAGE},
+ * in a more standardized way.
+ */
+public class Parameter {
+    public final String parameterHint;
+    private final String parameterName;
+    private final String[] parameterExampleValues;
+
+    /**
+     * Constructor for a {@code Parameter} that takes in the {@code parameterName}, {@code parameterHint}
+     * and valid {@code parameterExampleValues}, with at least one example value.
+     */
+    public Parameter(String parameterName, String parameterHint, String... parameterExampleValues) {
+        assert parameterName != null;
+        this.parameterName = parameterName;
+
+        this.parameterHint = parameterHint;
+
+        assert parameterExampleValues != null;
+        assert parameterExampleValues.length > 0;
+        this.parameterExampleValues = parameterExampleValues;
+    }
+
+    /**
+     * Constructor for a defined parameter that takes a {@code DefinedParameter}.
+     */
+    public Parameter(Parameter parameter) {
+        this.parameterName = parameter.parameterName;
+        this.parameterHint = parameter.parameterHint;
+        this.parameterExampleValues = parameter.parameterExampleValues;
+    }
+
+    public String getParameterName() {
+        return parameterName;
+    }
+
+    /**
+     * Gets the parameter hint or an empty string if no hint is present.
+     */
+    public String getParameterHint() {
+        return Optional.ofNullable(parameterHint)
+                .map(hint -> "(" + hint + ")")
+                .orElse("");
+    }
+
+    /**
+     * Gets the details of the parameter, which are the parameter name and hint appended behind.
+     */
+    public String getParameterDetails() {
+        return getParameterName() + " " + getParameterHint();
+    }
+
+    /**
+     * Gets an example value from the list of {@code parameterExampleValues},
+     * given an index {@code idx} from that list.
+     */
+    public String getParameterExampleValue(int idx) {
+        assert idx >= 0 && idx < parameterExampleValues.length;
+        return parameterExampleValues[idx];
+    }
+
+    /**
+     * Gets the parameter with the parameter example value, at index {@code idx}
+     * from {@code parameterExampleValues}, appended behind.
+     */
+    public String getParameterWithExampleValue(int idx) {
+        return getParameterExampleValue(idx);
+    }
+
+    /**
+     * Gets the first example value from the list of {@code parameterExampleValues}.
+     */
+    public String getParameterWithExampleValues() {
+        return getParameterWithExampleValue(0);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
+++ b/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands.util;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+/**
+ * Contains parameter syntax definitions and examples common to multiple commands.
+ */
+public class ParameterSyntax {
+
+    /* Parameter definitions */
+    public static final DefinedParameter PARAMETER_NAME = new DefinedParameter(
+            PREFIX_NAME,
+            "NAME",
+            "John Doe"
+    );
+
+    public static final DefinedParameter PARAMETER_PHONE = new DefinedParameter(
+            PREFIX_PHONE,
+            "PHONE",
+            "98765432"
+    );
+
+    public static final DefinedParameter PARAMETER_EMAIL = new DefinedParameter(
+            PREFIX_EMAIL,
+            "EMAIL",
+            "johndoe@example.com"
+    );
+
+    public static final DefinedParameter PARAMETER_NUSNET = new DefinedParameter(
+            PREFIX_NUSNET,
+            "NUSNET",
+            "e0123456"
+    );
+
+    public static final DefinedParameter PARAMETER_ADDRESS = new DefinedParameter(
+            PREFIX_ADDRESS,
+            "ADDRESS",
+            "311, Clementi Ave 2, #02-25"
+    );
+
+    public static final DefinedParameter PARAMETER_TAG = new DefinedParameter(
+            PREFIX_TAG,
+            "TAG",
+            "friends",
+            "owesMoney"
+    );
+
+    public static final Parameter PARAMETER_INDEX = new Parameter(
+            "INDEX",
+            "must be a positive integer",
+            "1"
+    );
+}

--- a/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
+++ b/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
@@ -13,37 +13,37 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 public class ParameterSyntax {
 
     /* Parameter definitions */
-    public static final DefinedParameter PARAMETER_NAME = new DefinedParameter(
+    public static final Parameter PARAMETER_NAME = new DefinedParameter(
             PREFIX_NAME,
             "NAME",
             "John Doe"
     );
 
-    public static final DefinedParameter PARAMETER_PHONE = new DefinedParameter(
+    public static final Parameter PARAMETER_PHONE = new DefinedParameter(
             PREFIX_PHONE,
             "PHONE",
             "98765432"
     );
 
-    public static final DefinedParameter PARAMETER_EMAIL = new DefinedParameter(
+    public static final Parameter PARAMETER_EMAIL = new DefinedParameter(
             PREFIX_EMAIL,
             "EMAIL",
             "johndoe@example.com"
     );
 
-    public static final DefinedParameter PARAMETER_NUSNET = new DefinedParameter(
+    public static final Parameter PARAMETER_NUSNET = new DefinedParameter(
             PREFIX_NUSNET,
             "NUSNET",
             "e0123456"
     );
 
-    public static final DefinedParameter PARAMETER_ADDRESS = new DefinedParameter(
+    public static final Parameter PARAMETER_ADDRESS = new DefinedParameter(
             PREFIX_ADDRESS,
             "ADDRESS",
             "311, Clementi Ave 2, #02-25"
     );
 
-    public static final DefinedParameter PARAMETER_TAG = new DefinedParameter(
+    public static final Parameter PARAMETER_TAG = new DefinedParameter(
             PREFIX_TAG,
             "TAG",
             "friends",

--- a/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.Prefix;
+
+class CommandMessageUsageUtilTest {
+    private Parameter p1;
+    private Parameter p2;
+    @BeforeEach
+    void setUp() {
+        p1 = new Parameter("ert", "cbs", "lmr");
+        p2 = new DefinedParameter(new Prefix("hic/"), "ban", "741", "qtz");
+    }
+
+    @Test
+    void generateMessageUsage() {
+        String messageUsage = CommandMessageUsageUtil
+                .generateMessageUsage("bad", "cat", "sed");
+        assertEquals("bad: cat\n"
+                + "Example: sed",
+                messageUsage);
+    }
+
+    @Test
+    void generateMessageUsage_withParameters() {
+        String messageUsage = CommandMessageUsageUtil
+                .generateMessageUsage("bad", "cat", p1, p2);
+        assertEquals("bad: cat\n"
+                + "Parameters: ert (cbs) hic/ban\n"
+                + "Example: bad lmr 741",
+                messageUsage);
+    }
+
+    @Test
+    void generateMessageUsage_withStringParameters() {
+        String messageUsage = CommandMessageUsageUtil
+                .generateMessageUsage("rad", "mad", "bet", "led");
+        assertEquals("rad: mad\n"
+                + "Parameters: bet\n"
+                + "Example: led",
+                messageUsage);
+    }
+
+    @Test
+    void generateMessageUsageParameters() {
+        String parameters = CommandMessageUsageUtil.generateMessageUsageParameters(p1, p2);
+        assertEquals("ert (cbs) hic/ban", parameters);
+    }
+
+    @Test
+    void generateMessageUsageExample() {
+        String example = CommandMessageUsageUtil.generateMessageUsageExample("TEM", p1, p2);
+        assertEquals("TEM lmr 741", example);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/util/DefinedParameterTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/DefinedParameterTest.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.Prefix;
+
+class DefinedParameterTest {
+
+    private Parameter parameter;
+    @BeforeEach
+    void setUp() {
+        Prefix prefix = new Prefix("cde/");
+        parameter = new DefinedParameter(prefix, "fgh", "135", "791");
+    }
+
+    @Test
+    void getParameterDetails() {
+        assertEquals("cde/fgh", parameter.getParameterDetails());
+    }
+
+    @Test
+    void asOptional_examplePresent() {
+        assertEquals("[cde/fgh] 135", parameter.asOptional(true).toString());
+    }
+
+    @Test
+    void asOptional_exampleNotPresent() {
+        assertEquals("[cde/fgh]", parameter.asOptional(false).toString());
+    }
+
+    @Test
+    void asMultiple_zeroExampleRepetitions() {
+        assertEquals("[cde/fgh]...", parameter.asMultiple(0).toString());
+    }
+
+    @Test
+    void asMultiple_oneExampleRepetitions() {
+        assertEquals("[cde/fgh]... 135", parameter.asMultiple(1).toString());
+    }
+
+    @Test
+    void asMultiple_twoExampleRepetitions() {
+        assertEquals("[cde/fgh]... 135 791", parameter.asMultiple(2).toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/util/ParameterTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/ParameterTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ParameterTest {
+    private Parameter parameter;
+    @BeforeEach
+    void setUp() {
+        parameter = new Parameter("abc", "def", "123", "456");
+    }
+
+    @Test
+    void getParameterName() {
+        assertEquals("abc", parameter.getParameterName());
+    }
+
+    @Test
+    void getParameterHint() {
+        assertEquals("(def)", parameter.getParameterHint());
+    }
+
+    @Test
+    void getParameterDetails() {
+        assertEquals("abc (def)", parameter.getParameterDetails());
+    }
+
+    @Test
+    void getFormattedParameterDetails() {
+        assertEquals("abc (def)", parameter.getParameterDetails());
+    }
+
+    @Test
+    void getParameterExampleValue_zeroIndex() {
+        assertEquals("123", parameter.getParameterExampleValue(0));
+    }
+
+    @Test
+    void getParameterExampleValue_firstIndex() {
+        assertEquals("456", parameter.getParameterExampleValue(1));
+    }
+
+    @Test
+    void getParameterWithExampleValues() {
+        assertEquals("123", parameter.getParameterWithExampleValues());
+    }
+
+    @Test
+    void asOptional_exampleNotPresent() {
+        assertEquals("[abc (def)]", parameter.asOptional(false).toString());
+    }
+
+    @Test
+    void asOptional_examplePresent() {
+        assertEquals("[abc (def)] 123", parameter.asOptional(true).toString());
+    }
+
+    @Test
+    void asMultiple_zeroExampleRepetitions() {
+        assertEquals("[abc (def)]...", parameter.asMultiple(0).toString());
+    }
+
+    @Test
+    void asMultiple_oneExampleRepetitions() {
+        assertEquals("[abc (def)]... 123", parameter.asMultiple(1).toString());
+    }
+
+    @Test
+    void asMultiple_twoExampleRepetitions() {
+        assertEquals("[abc (def)]... 123 456", parameter.asMultiple(2).toString());
+    }
+}


### PR DESCRIPTION
Adding utility classes for message usage helps with maintaining `MESSAGE_USAGE`, which is used by the `help` command.

It also makes editing/adding the `MESSAGE_USAGE` more easier for existing/new Commands.

Let's
* Add CommandUtil.java
* Add Parameter.java
* Add DefinedParameter.java
* Add ParameterSyntax.java
* Modify MESSAGE_USAGE in Commands

Related to #8: Will be displaying the `MESSAGE_USAGE` in the help window, so these helper classes help to ensure consistency in the format of the message usage, as currently it is just made up of inline string concatenations, which is bug prone and hard to maintain.

Resolves #40 