### PR TITLE
chore: Add test coverage report to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ bin/**
 .DS_Store
 docs/_site/
 docs/_markbind/logs/
+
+# IntelliJ test coverage report files
+/htmlReport/


### PR DESCRIPTION
Add IntelliJ test coverage generated report, `/htmlReport/`, to `gitignore`.