### PR TITLE
fix: CommandMessageUsageUtil missing prefix and extra spacing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
@@ -65,9 +65,12 @@ public class CommandMessageUsageUtil {
         StringBuilder stringBuilder = new StringBuilder(commandWord + " ");
 
         for (Parameter p : parameters) {
-            stringBuilder
-                    .append(p.getParameterWithExampleValues())
-                    .append(" ");
+            String exampleValue = p.getParameterWithExampleValues();
+            if (!exampleValue.isBlank()) {
+                stringBuilder
+                        .append(exampleValue)
+                        .append(" ");
+            }
         }
 
         return stringBuilder.toString().trim();

--- a/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/DefinedParameter.java
@@ -36,7 +36,14 @@ public class DefinedParameter extends Parameter {
 
     @Override
     public String getParameterDetails() {
-        return (prefix.getPrefix() + super.getParameterDetails()).trim();
+        String details = prefix.getPrefix() + super.getParameterDetails();
+        return details.trim();
+    }
+
+    @Override
+    public String getParameterExampleValue(int idx) {
+        String exampleValue = prefix.getPrefix() + super.getParameterExampleValue(idx);
+        return exampleValue.trim();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/util/Parameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/Parameter.java
@@ -70,7 +70,8 @@ public class Parameter {
      * Gets the details of the parameter, which are the parameter name and hint appended behind.
      */
     public String getParameterDetails() {
-        return (getParameterName() + " " + getParameterHint()).trim();
+        String details = getParameterName() + " " + getParameterHint();
+        return details.trim();
     }
 
     /**
@@ -134,6 +135,10 @@ public class Parameter {
 
     @Override
     public String toString() {
-        return (getFormattedParameterDetails() + " " + getParameterWithExampleValues()).trim();
+        return String.format(
+                "%s %s",
+                getFormattedParameterDetails(),
+                getParameterWithExampleValues()
+        ).trim();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
@@ -31,7 +31,7 @@ class CommandMessageUsageUtilTest {
                 .generateMessageUsage("bad", "cat", p1, p2);
         assertEquals("bad: cat\n"
                 + "Parameters: ert (cbs) hic/ban\n"
-                + "Example: bad lmr 741",
+                + "Example: bad lmr hic/741",
                 messageUsage);
     }
 
@@ -54,6 +54,16 @@ class CommandMessageUsageUtilTest {
     @Test
     void generateMessageUsageExample() {
         String example = CommandMessageUsageUtil.generateMessageUsageExample("TEM", p1, p2);
-        assertEquals("TEM lmr 741", example);
+        assertEquals("TEM lmr hic/741", example);
+    }
+
+    @Test
+    void generateMessageUsageExample_withOptionalParameters() {
+        String example = CommandMessageUsageUtil.generateMessageUsageExample(
+                "TEM",
+                p1.asOptional(false),
+                p2.asOptional(true)
+        );
+        assertEquals("TEM hic/741", example);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/util/DefinedParameterTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/DefinedParameterTest.java
@@ -23,7 +23,7 @@ class DefinedParameterTest {
 
     @Test
     void asOptional_examplePresent() {
-        assertEquals("[cde/fgh] 135", parameter.asOptional(true).toString());
+        assertEquals("[cde/fgh] cde/135", parameter.asOptional(true).toString());
     }
 
     @Test
@@ -38,11 +38,11 @@ class DefinedParameterTest {
 
     @Test
     void asMultiple_oneExampleRepetitions() {
-        assertEquals("[cde/fgh]... 135", parameter.asMultiple(1).toString());
+        assertEquals("[cde/fgh]... cde/135", parameter.asMultiple(1).toString());
     }
 
     @Test
     void asMultiple_twoExampleRepetitions() {
-        assertEquals("[cde/fgh]... 135 791", parameter.asMultiple(2).toString());
+        assertEquals("[cde/fgh]... cde/135 cde/791", parameter.asMultiple(2).toString());
     }
 }


### PR DESCRIPTION
Let's fix the issues:
* extra spacing not removed when optional parameter example not present
* missing prefix in example

Tests have been updated to cover these issues.

Now the prefix is present in the example `addstu`:

![Screenshot 2024-03-18 003244](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/513100f3-4ea4-4e34-accb-f66953189afb)

Resolves: #51 