### PR TITLE
docs: Add UML diagrams for commands.util

### DIFF
--- a/docs/diagrams/CommandsUtilClassDiagram.puml
+++ b/docs/diagrams/CommandsUtilClassDiagram.puml
@@ -1,0 +1,26 @@
+@startuml
+!include style.puml
+skinparam arrowThickness 1.1
+skinparam arrowColor LOGIC_COLOR_T4
+skinparam classBackgroundColor LOGIC_COLOR
+
+package "Commands Utility Classes" as CommandsUtil {
+Class DefinedParameter
+Class Parameter
+Class ParameterSyntax
+Class CommandMessageUsageUtil
+}
+
+Class Prefix
+
+Class HiddenOutside1 #FFFFFF
+Class HiddenOutside2 #FFFFFF
+HiddenOutside1 .down.> CommandMessageUsageUtil
+HiddenOutside2 .down.> ParameterSyntax
+
+CommandMessageUsageUtil .down.> Parameter
+DefinedParameter -right-> Prefix
+DefinedParameter .left.|> Parameter
+ParameterSyntax .down.> DefinedParameter
+ParameterSyntax .down.> Parameter
+@enduml

--- a/docs/diagrams/LogicClassDiagram.puml
+++ b/docs/diagrams/LogicClassDiagram.puml
@@ -12,9 +12,11 @@ Class XYZCommand
 Class CommandResult
 Class "{abstract}\nCommand" as Command
 
-
 Class "<<interface>>\nLogic" as Logic
 Class LogicManager
+
+package "Commands Utility Classes" as CommandsUtil {
+}
 }
 
 package Model {
@@ -30,6 +32,7 @@ HiddenOutside ..> Logic
 LogicManager .right.|> Logic
 LogicManager -right->"1" ParserClasses
 ParserClasses ..> XYZCommand : <<create>>
+XYZCommand .down.> CommandsUtil
 
 XYZCommand -up-|> Command
 LogicManager .left.> Command : <<call>>


### PR DESCRIPTION
Here are the UML diagrams I updated for reference:

![image](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/f6d96016-acef-4a3c-acc3-804541310e9a)

![image](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/8748ded9-8f8d-4b8a-83cd-d81315e103de)

Note that `Commands Utility Classes` is not in the DG yet, as it is a lower level diagram that isn't really suitable to be directly in the main DG page as of now, but could be in a separate page eventually.