### PR TITLE
feat: autocomplete nusnet id

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -37,8 +37,7 @@ import seedu.address.storage.Storage;
  */
 public class LogicManager implements Logic {
     public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
-
-    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s due to"
+    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s due to "
         + "insufficient permissions to write to the file or the folder.";
 
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.autocomplete.AutoComplete;
 import seedu.address.logic.autocomplete.AutoCompleteCommand;
+import seedu.address.logic.autocomplete.AutoCompleteNusNetId;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -35,105 +36,111 @@ import seedu.address.storage.Storage;
  * The main LogicManager of the app.
  */
 public class LogicManager implements Logic {
-    public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
+  public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
 
-    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT =
-            "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
+  public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
 
-    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
+  private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
-    private final Model model;
-    private final Storage storage;
-    private final AddressBookParser addressBookParser;
+  private final Model model;
+  private final Storage storage;
+  private final AddressBookParser addressBookParser;
 
-    /**
-     * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
-     */
-    public LogicManager(Model model, Storage storage) {
-        this.model = model;
-        this.storage = storage;
-        addressBookParser = new AddressBookParser();
-        this.initialize();
+  /**
+   * Constructs a {@code LogicManager} with the given {@code Model} and
+   * {@code Storage}.
+   */
+  public LogicManager(Model model, Storage storage) {
+    this.model = model;
+    this.storage = storage;
+    addressBookParser = new AddressBookParser();
+    this.initialize();
+  }
+
+  @Override
+  public CommandResult execute(String commandText) throws CommandException, ParseException {
+    logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+    Command command = addressBookParser.parseCommand(commandText);
+    CommandResult commandResult = command.execute(model);
+
+    try {
+      storage.saveAddressBook(model.getAddressBook());
+      storage.saveCourse(model.getCourseName());
+    } catch (AccessDeniedException e) {
+      throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+    } catch (IOException ioe) {
+      throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
     }
 
-    @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
-        logger.info("----------------[USER COMMAND][" + commandText + "]");
+    return commandResult;
+  }
 
+  @Override
+  public String autoComplete(String commandText) {
+    AutoComplete ac = addressBookParser.parseAutoComplete(commandText);
+    assert ac != null;
+    return ac.getAutoComplete(commandText);
+  }
 
-        Command command = addressBookParser.parseCommand(commandText);
-        CommandResult commandResult = command.execute(model);
+  /**
+   * Initializes various miscellaneous initializations for the logic manager.
+   */
+  private void initialize() {
+    // Initialize the autocomplete for the commands
+    AutoCompleteCommand.initialize(
+        AddPersonCommand.COMMAND_WORD,
+        EditPersonCommand.COMMAND_WORD,
+        DeletePersonCommand.COMMAND_WORD,
+        ClearCommand.COMMAND_WORD,
+        FindPersonCommand.COMMAND_WORD,
+        ListPersonCommand.COMMAND_WORD,
+        MarkAttendanceCommand.COMMAND_WORD,
+        UnmarkAttendanceCommand.COMMAND_WORD,
+        ExitCommand.COMMAND_WORD,
+        HelpCommand.COMMAND_WORD);
 
-        try {
-            storage.saveAddressBook(model.getAddressBook());
-            storage.saveCourse(model.getCourseName());
-        } catch (AccessDeniedException e) {
-            throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
-        } catch (IOException ioe) {
-            throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
-        }
+    // Initialize the autocomplete for the NUSNET IDs
+    AutoCompleteNusNetId.initialize(
+        getAddressBook()
+            .getPersonList()
+            .stream()
+            .map(person -> person.getNusNet().value)
+            .toArray(String[]::new));
+  }
 
-        return commandResult;
-    }
+  @Override
+  public ReadOnlyAddressBook getAddressBook() {
+    return model.getAddressBook();
+  }
 
-    @Override
-    public String autoComplete(String commandText) {
-        AutoComplete ac = addressBookParser.parseAutoComplete(commandText);
-        assert ac != null;
-        return ac.getAutoComplete(commandText);
-    }
+  @Override
+  public ObservableList<Person> getFilteredPersonList() {
+    return model.getFilteredPersonList();
+  }
 
-    /**
-     * Initializes various miscellaneous initializations for the logic manager.
-     */
-    private void initialize() {
-        // Initialize the autocomplete for the commands
-        AutoCompleteCommand.initialize(
-                AddPersonCommand.COMMAND_WORD,
-                EditPersonCommand.COMMAND_WORD,
-                DeletePersonCommand.COMMAND_WORD,
-                ClearCommand.COMMAND_WORD,
-                FindPersonCommand.COMMAND_WORD,
-                ListPersonCommand.COMMAND_WORD,
-                MarkAttendanceCommand.COMMAND_WORD,
-                UnmarkAttendanceCommand.COMMAND_WORD,
-                ExitCommand.COMMAND_WORD,
-                HelpCommand.COMMAND_WORD
-        );
-    }
+  @Override
+  public Path getAddressBookFilePath() {
+    return model.getAddressBookFilePath();
+  }
 
-    @Override
-    public ReadOnlyAddressBook getAddressBook() {
-        return model.getAddressBook();
-    }
+  @Override
+  public GuiSettings getGuiSettings() {
+    return model.getGuiSettings();
+  }
 
-    @Override
-    public ObservableList<Person> getFilteredPersonList() {
-        return model.getFilteredPersonList();
-    }
+  @Override
+  public void setGuiSettings(GuiSettings guiSettings) {
+    model.setGuiSettings(guiSettings);
+  }
 
-    @Override
-    public Path getAddressBookFilePath() {
-        return model.getAddressBookFilePath();
-    }
+  @Override
+  public ReadOnlyCourseName getCourseName() {
+    return model.getCourseName();
+  }
 
-    @Override
-    public GuiSettings getGuiSettings() {
-        return model.getGuiSettings();
-    }
-
-    @Override
-    public void setGuiSettings(GuiSettings guiSettings) {
-        model.setGuiSettings(guiSettings);
-    }
-
-    @Override
-    public ReadOnlyCourseName getCourseName() {
-        return model.getCourseName();
-    }
-
-    @Override
-    public Path getCourseNameFilePath() {
-        return model.getCourseNameFilePath();
-    }
+  @Override
+  public Path getCourseNameFilePath() {
+    return model.getCourseNameFilePath();
+  }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -36,123 +36,126 @@ import seedu.address.storage.Storage;
  * The main LogicManager of the app.
  */
 public class LogicManager implements Logic {
-  public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
+    public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
 
-  public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
+    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s due to"
+        + "insufficient permissions to write to the file or the folder.";
 
-  private final Logger logger = LogsCenter.getLogger(LogicManager.class);
+    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
-  private final Model model;
-  private final Storage storage;
-  private final AddressBookParser addressBookParser;
+    private final Model model;
+    private final Storage storage;
+    private final AddressBookParser addressBookParser;
 
-  /**
-   * Constructs a {@code LogicManager} with the given {@code Model} and
-   * {@code Storage}.
-   */
-  public LogicManager(Model model, Storage storage) {
-    this.model = model;
-    this.storage = storage;
-    addressBookParser = new AddressBookParser();
-    this.initialize();
-  }
-
-  @Override
-  public CommandResult execute(String commandText) throws CommandException, ParseException {
-    logger.info("----------------[USER COMMAND][" + commandText + "]");
-
-    Command command = addressBookParser.parseCommand(commandText);
-    CommandResult commandResult = command.execute(model);
-
-    if (command instanceof AddPersonCommand
-        || command instanceof DeletePersonCommand
-        || command instanceof EditPersonCommand) { // Update the autocomplete for the NUSNET IDs if the command
-                                                   // potentially modifies the NUSNET IDs
-      AutoCompleteNusNetId.update(
-          getAddressBook()
-              .getPersonList()
-              .stream()
-              .map(person -> person.getNusNet().value)
-              .toArray(String[]::new));
+    /**
+     * Constructs a {@code LogicManager} with the given {@code Model} and
+     * {@code Storage}.
+     */
+    public LogicManager(Model model, Storage storage) {
+        this.model = model;
+        this.storage = storage;
+        addressBookParser = new AddressBookParser();
+        this.initialize();
     }
 
-    try {
-      storage.saveAddressBook(model.getAddressBook());
-      storage.saveCourse(model.getCourseName());
-    } catch (AccessDeniedException e) {
-      throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
-    } catch (IOException ioe) {
-      throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+    @Override
+    public CommandResult execute(String commandText) throws CommandException, ParseException {
+        logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        Command command = addressBookParser.parseCommand(commandText);
+        CommandResult commandResult = command.execute(model);
+
+        // Update the autocomplete for the NUSNET IDs if the command
+        // potentially modifies the NUSNET IDs
+        if (command instanceof AddPersonCommand
+            || command instanceof DeletePersonCommand
+            || command instanceof EditPersonCommand) {
+
+            AutoCompleteNusNetId.update(
+                getAddressBook()
+                    .getPersonList()
+                    .stream()
+                    .map(person -> person.getNusNet().value)
+                    .toArray(String[]::new));
+        }
+
+        try {
+            storage.saveAddressBook(model.getAddressBook());
+            storage.saveCourse(model.getCourseName());
+        } catch (AccessDeniedException e) {
+            throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+        } catch (IOException ioe) {
+            throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+        }
+
+        return commandResult;
     }
 
-    return commandResult;
-  }
+    @Override
+    public String autoComplete(String commandText) {
+        AutoComplete ac = addressBookParser.parseAutoComplete(commandText);
+        assert ac != null;
+        return ac.getAutoComplete(commandText);
+    }
 
-  @Override
-  public String autoComplete(String commandText) {
-    AutoComplete ac = addressBookParser.parseAutoComplete(commandText);
-    assert ac != null;
-    return ac.getAutoComplete(commandText);
-  }
+    /**
+     * Initializes various miscellaneous initializations for the logic manager.
+     */
+    private void initialize() {
+        // Initialize the autocomplete for the commands
+        AutoCompleteCommand.initialize(
+            AddPersonCommand.COMMAND_WORD,
+            EditPersonCommand.COMMAND_WORD,
+            DeletePersonCommand.COMMAND_WORD,
+            ClearCommand.COMMAND_WORD,
+            FindPersonCommand.COMMAND_WORD,
+            ListPersonCommand.COMMAND_WORD,
+            MarkAttendanceCommand.COMMAND_WORD,
+            UnmarkAttendanceCommand.COMMAND_WORD,
+            ExitCommand.COMMAND_WORD,
+            HelpCommand.COMMAND_WORD);
 
-  /**
-   * Initializes various miscellaneous initializations for the logic manager.
-   */
-  private void initialize() {
-    // Initialize the autocomplete for the commands
-    AutoCompleteCommand.initialize(
-        AddPersonCommand.COMMAND_WORD,
-        EditPersonCommand.COMMAND_WORD,
-        DeletePersonCommand.COMMAND_WORD,
-        ClearCommand.COMMAND_WORD,
-        FindPersonCommand.COMMAND_WORD,
-        ListPersonCommand.COMMAND_WORD,
-        MarkAttendanceCommand.COMMAND_WORD,
-        UnmarkAttendanceCommand.COMMAND_WORD,
-        ExitCommand.COMMAND_WORD,
-        HelpCommand.COMMAND_WORD);
+        // Initialize the autocomplete for the NUSNET IDs
+        AutoCompleteNusNetId.initialize(
+            getAddressBook()
+                .getPersonList()
+                .stream()
+                .map(person -> person.getNusNet().value)
+                .toArray(String[]::new));
+    }
 
-    // Initialize the autocomplete for the NUSNET IDs
-    AutoCompleteNusNetId.initialize(
-        getAddressBook()
-            .getPersonList()
-            .stream()
-            .map(person -> person.getNusNet().value)
-            .toArray(String[]::new));
-  }
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return model.getAddressBook();
+    }
 
-  @Override
-  public ReadOnlyAddressBook getAddressBook() {
-    return model.getAddressBook();
-  }
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        return model.getFilteredPersonList();
+    }
 
-  @Override
-  public ObservableList<Person> getFilteredPersonList() {
-    return model.getFilteredPersonList();
-  }
+    @Override
+    public Path getAddressBookFilePath() {
+        return model.getAddressBookFilePath();
+    }
 
-  @Override
-  public Path getAddressBookFilePath() {
-    return model.getAddressBookFilePath();
-  }
+    @Override
+    public GuiSettings getGuiSettings() {
+        return model.getGuiSettings();
+    }
 
-  @Override
-  public GuiSettings getGuiSettings() {
-    return model.getGuiSettings();
-  }
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        model.setGuiSettings(guiSettings);
+    }
 
-  @Override
-  public void setGuiSettings(GuiSettings guiSettings) {
-    model.setGuiSettings(guiSettings);
-  }
+    @Override
+    public ReadOnlyCourseName getCourseName() {
+        return model.getCourseName();
+    }
 
-  @Override
-  public ReadOnlyCourseName getCourseName() {
-    return model.getCourseName();
-  }
-
-  @Override
-  public Path getCourseNameFilePath() {
-    return model.getCourseNameFilePath();
-  }
+    @Override
+    public Path getCourseNameFilePath() {
+        return model.getCourseNameFilePath();
+    }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -64,6 +64,18 @@ public class LogicManager implements Logic {
     Command command = addressBookParser.parseCommand(commandText);
     CommandResult commandResult = command.execute(model);
 
+    if (command instanceof AddPersonCommand
+        || command instanceof DeletePersonCommand
+        || command instanceof EditPersonCommand) { // Update the autocomplete for the NUSNET IDs if the command
+                                                   // potentially modifies the NUSNET IDs
+      AutoCompleteNusNetId.update(
+          getAddressBook()
+              .getPersonList()
+              .stream()
+              .map(person -> person.getNusNet().value)
+              .toArray(String[]::new));
+    }
+
     try {
       storage.saveAddressBook(model.getAddressBook());
       storage.saveCourse(model.getCourseName());

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.autocomplete;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.util.Trie;
+
+/**
+ * AutoComplete for NUSNET ID
+ */
+public class AutoCompleteNusNetId implements AutoComplete {
+    private static Trie nusNetIdTrie;
+    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
+
+    /**
+     * Initializes the NUSNET ID trie with the given NUSNET IDs. This method should be called once at
+     * the start of the initialization of LogicManager.
+     * @param nusNetIds the NUSNET IDs to initialize the trie with
+     */
+    public static void initialize(String... nusNetIds) {
+        nusNetIdTrie = new Trie(Arrays.stream(nusNetIds).map(String::toUpperCase).toArray(String[]::new));
+    }
+
+    /**
+     * Update the NUSNET ID trie with the given NUSNET IDs. This method is just a wrapper for the
+     * initialize method in Trie to make the intention clearer.
+     * @param nusNetIds the NUSNET IDs to update the trie with
+     */
+    public static void update(String... nusNetIds) {
+        initialize(nusNetIds);
+    }
+
+    @Override
+    public String getAutoComplete(String input) {
+        assert nusNetIdTrie != null;
+
+        System.out.println("AutoCompleteNusNetId: " + input);
+
+        Matcher m = NUSNET_ID_FORMAT.matcher(input);
+        boolean isNusNetId = m.find();
+        assert isNusNetId;
+
+        String partialNusNetId = m.group(1);
+        String fullNusNetId = nusNetIdTrie.findFirstWordWithPrefix(partialNusNetId.toUpperCase());
+
+        if (fullNusNetId == null || fullNusNetId.isEmpty()) {
+            return "";
+        }
+
+        // Strip the input from the full command
+        return fullNusNetId.substring(partialNusNetId.length());
+    }
+}

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
@@ -35,8 +35,6 @@ public class AutoCompleteNusNetId implements AutoComplete {
     public String getAutoComplete(String input) {
         assert nusNetIdTrie != null;
 
-        System.out.println("AutoCompleteNusNetId: " + input);
-
         Matcher m = NUSNET_ID_FORMAT.matcher(input);
         boolean isNusNetId = m.find();
         assert isNusNetId;

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.autocomplete;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
+
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -11,11 +13,12 @@ import seedu.address.commons.util.Trie;
  */
 public class AutoCompleteNusNetId implements AutoComplete {
     private static Trie nusNetIdTrie;
-    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
+    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile(PREFIX_NUSNET.getPrefix() + "(.*)");
 
     /**
      * Initializes the NUSNET ID trie with the given NUSNET IDs. This method should be called once at
      * the start of the initialization of LogicManager.
+     *
      * @param nusNetIds the NUSNET IDs to initialize the trie with
      */
     public static void initialize(String... nusNetIds) {
@@ -25,6 +28,7 @@ public class AutoCompleteNusNetId implements AutoComplete {
     /**
      * Update the NUSNET ID trie with the given NUSNET IDs. This method is just a wrapper for the
      * initialize method in Trie to make the intention clearer.
+     *
      * @param nusNetIds the NUSNET IDs to update the trie with
      */
     public static void update(String... nusNetIds) {

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
@@ -42,7 +42,8 @@ public class AutoCompleteNusNetId implements AutoComplete {
         String partialNusNetId = m.group(1);
         String fullNusNetId = nusNetIdTrie.findFirstWordWithPrefix(partialNusNetId.toUpperCase());
 
-        if (fullNusNetId == null || fullNusNetId.isEmpty()) {
+        assert fullNusNetId != null;
+        if (fullNusNetId.isEmpty()) {
             return "";
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.autocomplete.AutoComplete;
 import seedu.address.logic.autocomplete.AutoCompleteCommand;
+import seedu.address.logic.autocomplete.AutoCompleteNusNetId;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -29,54 +30,56 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class AddressBookParser {
 
-    /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
-    private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
-    private static final String COMMAND_WORD_GROUP = "commandWord";
-    private static final String ARGUMENTS_GROUP = "arguments";
+  /**
+   * Used for initial separation of command word and args.
+   */
+  private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+  private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
+  private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+  private static final String COMMAND_WORD_GROUP = "commandWord";
+  private static final String ARGUMENTS_GROUP = "arguments";
 
-    /**
-     * Parses user input into command for execution.
-     *
-     * @param userInput full user input string
-     * @return the command based on the user input
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    public Command parseCommand(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-        }
+  /**
+   * Parses user input into command for execution.
+   *
+   * @param userInput full user input string
+   * @return the command based on the user input
+   * @throws ParseException if the user input does not conform the expected format
+   */
+  public Command parseCommand(String userInput) throws ParseException {
+    final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+    if (!matcher.matches()) {
+      throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+    }
 
-        final String commandWord = matcher.group(COMMAND_WORD_GROUP);
-        final String arguments = matcher.group(ARGUMENTS_GROUP);
+    final String commandWord = matcher.group(COMMAND_WORD_GROUP);
+    final String arguments = matcher.group(ARGUMENTS_GROUP);
 
-        // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)
-        // log messages such as the one below.
-        // Lower level log messages are used sparingly to minimize noise in the code.
-        logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
+    // Note to developers: Change the log level in config.json to enable lower level
+    // (i.e., FINE, FINER and lower)
+    // log messages such as the one below.
+    // Lower level log messages are used sparingly to minimize noise in the code.
+    logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
+    switch (commandWord) {
 
-        case AddPersonCommand.COMMAND_WORD:
-            return new AddPersonCommandParser().parse(arguments);
+      case AddPersonCommand.COMMAND_WORD:
+        return new AddPersonCommandParser().parse(arguments);
 
-        case EditPersonCommand.COMMAND_WORD:
-            return new EditPersonCommandParser().parse(arguments);
+      case EditPersonCommand.COMMAND_WORD:
+        return new EditPersonCommandParser().parse(arguments);
 
-        case DeletePersonCommand.COMMAND_WORD:
-            return new DeletePersonCommandParser().parse(arguments);
+      case DeletePersonCommand.COMMAND_WORD:
+        return new DeletePersonCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+      case ClearCommand.COMMAND_WORD:
+        return new ClearCommand();
 
-        case FindPersonCommand.COMMAND_WORD:
-            return new FindPersonCommandParser().parse(arguments);
+      case FindPersonCommand.COMMAND_WORD:
+        return new FindPersonCommandParser().parse(arguments);
 
-        case ListPersonCommand.COMMAND_WORD:
-            return new ListPersonCommand();
+      case ListPersonCommand.COMMAND_WORD:
+        return new ListPersonCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -84,38 +87,42 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case SetCourseCommand.COMMAND_WORD:
-            return new SetCourseCommandParser().parse(arguments);
+      case SetCourseCommand.COMMAND_WORD:
+        return new SetCourseCommandParser().parse(arguments);
 
-        case MarkAttendanceCommand.COMMAND_WORD:
-            return new MarkAttendanceCommandParser().parse(arguments);
+      case MarkAttendanceCommand.COMMAND_WORD:
+        return new MarkAttendanceCommandParser().parse(arguments);
 
-        case UnmarkAttendanceCommand.COMMAND_WORD:
-            return new UnmarkAttendanceCommandParser().parse(arguments);
+      case UnmarkAttendanceCommand.COMMAND_WORD:
+        return new UnmarkAttendanceCommandParser().parse(arguments);
 
-        default:
-            logger.finer("This user input caused a ParseException: " + userInput);
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
-        }
+      default:
+        logger.finer("This user input caused a ParseException: " + userInput);
+        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+    }
+  }
+
+  /**
+   * Parses the full input text and returns the appropriate autocomplete object.
+   */
+  public AutoComplete parseAutoComplete(String userInput) {
+    final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+    if (!matcher.matches()) {
+      logger.finer("Unable to parse user input for autocomplete: " + userInput);
+      return input -> "";
     }
 
-    /**
-     * Parses the full input text and returns the appropriate autocomplete object.
-     */
-    public AutoComplete parseAutoComplete(String userInput) {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            logger.finer("Unable to parse user input for autocomplete: " + userInput);
-            return input -> "";
-        }
+    final String arguments = matcher.group(ARGUMENTS_GROUP);
 
-        final String arguments = matcher.group(ARGUMENTS_GROUP);
-
-        // no arguments, return autocomplete for command word
-        if (arguments.isEmpty()) {
-            return new AutoCompleteCommand();
-        }
-
-        return input -> "";
+    // no arguments, return autocomplete for command word
+    if (arguments.isEmpty()) {
+      return new AutoCompleteCommand();
     }
+
+    if (NUSNET_ID_FORMAT.matcher(arguments).find()) {
+      return new AutoCompleteNusNetId();
+    }
+
+    return input -> "";
+  }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
 
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -34,7 +35,7 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
-    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
+    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile(PREFIX_NUSNET.getPrefix() + "(.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
     private static final String COMMAND_WORD_GROUP = "commandWord";
     private static final String ARGUMENTS_GROUP = "arguments";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -30,56 +30,56 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class AddressBookParser {
 
-  /**
-   * Used for initial separation of command word and args.
-   */
-  private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
-  private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
-  private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
-  private static final String COMMAND_WORD_GROUP = "commandWord";
-  private static final String ARGUMENTS_GROUP = "arguments";
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    private static final Pattern NUSNET_ID_FORMAT = Pattern.compile("nn/(.*)");
+    private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+    private static final String COMMAND_WORD_GROUP = "commandWord";
+    private static final String ARGUMENTS_GROUP = "arguments";
 
-  /**
-   * Parses user input into command for execution.
-   *
-   * @param userInput full user input string
-   * @return the command based on the user input
-   * @throws ParseException if the user input does not conform the expected format
-   */
-  public Command parseCommand(String userInput) throws ParseException {
-    final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-    if (!matcher.matches()) {
-      throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-    }
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
 
-    final String commandWord = matcher.group(COMMAND_WORD_GROUP);
-    final String arguments = matcher.group(ARGUMENTS_GROUP);
+        final String commandWord = matcher.group(COMMAND_WORD_GROUP);
+        final String arguments = matcher.group(ARGUMENTS_GROUP);
 
-    // Note to developers: Change the log level in config.json to enable lower level
-    // (i.e., FINE, FINER and lower)
-    // log messages such as the one below.
-    // Lower level log messages are used sparingly to minimize noise in the code.
-    logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
+        // Note to developers: Change the log level in config.json to enable lower level
+        // (i.e., FINE, FINER and lower)
+        // log messages such as the one below.
+        // Lower level log messages are used sparingly to minimize noise in the code.
+        logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-    switch (commandWord) {
+        switch (commandWord) {
 
-      case AddPersonCommand.COMMAND_WORD:
-        return new AddPersonCommandParser().parse(arguments);
+        case AddPersonCommand.COMMAND_WORD:
+            return new AddPersonCommandParser().parse(arguments);
 
-      case EditPersonCommand.COMMAND_WORD:
-        return new EditPersonCommandParser().parse(arguments);
+        case EditPersonCommand.COMMAND_WORD:
+            return new EditPersonCommandParser().parse(arguments);
 
-      case DeletePersonCommand.COMMAND_WORD:
-        return new DeletePersonCommandParser().parse(arguments);
+        case DeletePersonCommand.COMMAND_WORD:
+            return new DeletePersonCommandParser().parse(arguments);
 
-      case ClearCommand.COMMAND_WORD:
-        return new ClearCommand();
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
-      case FindPersonCommand.COMMAND_WORD:
-        return new FindPersonCommandParser().parse(arguments);
+        case FindPersonCommand.COMMAND_WORD:
+            return new FindPersonCommandParser().parse(arguments);
 
-      case ListPersonCommand.COMMAND_WORD:
-        return new ListPersonCommand();
+        case ListPersonCommand.COMMAND_WORD:
+            return new ListPersonCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -87,42 +87,42 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-      case SetCourseCommand.COMMAND_WORD:
-        return new SetCourseCommandParser().parse(arguments);
+        case SetCourseCommand.COMMAND_WORD:
+            return new SetCourseCommandParser().parse(arguments);
 
-      case MarkAttendanceCommand.COMMAND_WORD:
-        return new MarkAttendanceCommandParser().parse(arguments);
+        case MarkAttendanceCommand.COMMAND_WORD:
+            return new MarkAttendanceCommandParser().parse(arguments);
 
-      case UnmarkAttendanceCommand.COMMAND_WORD:
-        return new UnmarkAttendanceCommandParser().parse(arguments);
+        case UnmarkAttendanceCommand.COMMAND_WORD:
+            return new UnmarkAttendanceCommandParser().parse(arguments);
 
-      default:
-        logger.finer("This user input caused a ParseException: " + userInput);
-        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
-    }
-  }
-
-  /**
-   * Parses the full input text and returns the appropriate autocomplete object.
-   */
-  public AutoComplete parseAutoComplete(String userInput) {
-    final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-    if (!matcher.matches()) {
-      logger.finer("Unable to parse user input for autocomplete: " + userInput);
-      return input -> "";
+        default:
+            logger.finer("This user input caused a ParseException: " + userInput);
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
     }
 
-    final String arguments = matcher.group(ARGUMENTS_GROUP);
+    /**
+     * Parses the full input text and returns the appropriate autocomplete object.
+     */
+    public AutoComplete parseAutoComplete(String userInput) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            logger.finer("Unable to parse user input for autocomplete: " + userInput);
+            return input -> "";
+        }
 
-    // no arguments, return autocomplete for command word
-    if (arguments.isEmpty()) {
-      return new AutoCompleteCommand();
+        final String arguments = matcher.group(ARGUMENTS_GROUP);
+
+        // no arguments, return autocomplete for command word
+        if (arguments.isEmpty()) {
+            return new AutoCompleteCommand();
+        }
+
+        if (NUSNET_ID_FORMAT.matcher(arguments).find()) {
+            return new AutoCompleteNusNetId();
+        }
+
+        return input -> "";
     }
-
-    if (NUSNET_ID_FORMAT.matcher(arguments).find()) {
-      return new AutoCompleteNusNetId();
-    }
-
-    return input -> "";
-  }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.autocomplete;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class AutoCompleteNusNetIdTest {
+
+    @Test
+    void getAutoComplete() {
+        AutoCompleteNusNetId.initialize(
+          "e1234567",
+          "e7654321",
+          "e0000000"
+        );
+
+        AutoComplete ac = new AutoCompleteNusNetId();
+
+        System.out.println(ac.getAutoComplete("e1"));
+
+        assertEquals("234567", ac.getAutoComplete("nn/e1"));
+        assertEquals("654321", ac.getAutoComplete("nn/e7"));
+        assertEquals("000000", ac.getAutoComplete("nn/e0"));
+
+        AutoCompleteNusNetId.update(
+          "e1111111",
+          "e2222222",
+          "e3333333"
+        );
+
+        assertEquals("111111", ac.getAutoComplete("nn/e1"));
+        assertEquals("222222", ac.getAutoComplete("nn/e2"));
+        assertEquals("333333", ac.getAutoComplete("nn/e3"));
+    }
+}

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.autocomplete;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 class AutoCompleteNusNetIdTest {
@@ -8,27 +9,29 @@ class AutoCompleteNusNetIdTest {
     @Test
     void getAutoComplete() {
         AutoCompleteNusNetId.initialize(
-          "e1234567",
-          "e7654321",
-          "e0000000"
+              "e1234567",
+              "e7654321",
+              "e0000000"
         );
 
         AutoComplete ac = new AutoCompleteNusNetId();
-
-        System.out.println(ac.getAutoComplete("e1"));
 
         assertEquals("234567", ac.getAutoComplete("nn/e1"));
         assertEquals("654321", ac.getAutoComplete("nn/e7"));
         assertEquals("000000", ac.getAutoComplete("nn/e0"));
 
         AutoCompleteNusNetId.update(
-          "e1111111",
-          "e2222222",
-          "e3333333"
+              "e1111111",
+              "e2222222",
+              "e3333333"
         );
 
         assertEquals("111111", ac.getAutoComplete("nn/e1"));
         assertEquals("222222", ac.getAutoComplete("nn/e2"));
         assertEquals("333333", ac.getAutoComplete("nn/e3"));
+
+        AutoCompleteNusNetId.update();
+
+        assertEquals("", ac.getAutoComplete("nn/e1"));
     }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
@@ -30,7 +30,7 @@ class AutoCompleteNusNetIdTest {
         assertEquals("222222", ac.getAutoComplete("nn/e2"));
         assertEquals("333333", ac.getAutoComplete("nn/e3"));
 
-        AutoCompleteNusNetId.update();
+        AutoCompleteNusNetId.update(); // Clear all NUSNET IDs
 
         assertEquals("", ac.getAutoComplete("nn/e1"));
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.autocomplete.AutoComplete;
 import seedu.address.logic.autocomplete.AutoCompleteCommand;
+import seedu.address.logic.autocomplete.AutoCompleteNusNetId;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandTestUtil;
@@ -43,118 +44,117 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+  private final AddressBookParser parser = new AddressBookParser();
 
-    @Test
-    public void parseCommand_add() throws Exception {
-        Person person = new PersonBuilder().build();
-        AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-        assertEquals(new AddPersonCommand(person), command);
-    }
+  @Test
+  public void parseCommand_add() throws Exception {
+    Person person = new PersonBuilder().build();
+    AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+    assertEquals(new AddPersonCommand(person), command);
+  }
 
-    @Test
-    public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
-    }
+  @Test
+  public void parseCommand_clear() throws Exception {
+    assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
+    assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+  }
 
-    @Test
-    public void parseCommand_delete() throws Exception {
-        DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
-                DeletePersonCommand.COMMAND_WORD + " " + CommandTestUtil.VALID_NUSNET_AMY);
-        assertEquals(new DeletePersonCommand(new NusNet(CommandTestUtil.VALID_NUSNET_AMY)), command);
-    }
+  @Test
+  public void parseCommand_delete() throws Exception {
+    DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
+        DeletePersonCommand.COMMAND_WORD + " " + CommandTestUtil.VALID_NUSNET_AMY);
+    assertEquals(new DeletePersonCommand(new NusNet(CommandTestUtil.VALID_NUSNET_AMY)), command);
+  }
 
-    @Test
-    public void parseCommand_edit() throws Exception {
-        Person person = new PersonBuilder().build();
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-        EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD
-                + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
-    }
+  @Test
+  public void parseCommand_edit() throws Exception {
+    Person person = new PersonBuilder().build();
+    EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
+    EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD
+        + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+    assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
+  }
 
-    @Test
-    public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
-    }
+  @Test
+  public void parseCommand_exit() throws Exception {
+    assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+    assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+  }
 
-    @Test
-    public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindPersonCommand command = (FindPersonCommand) parser.parseCommand(
-                FindPersonCommand.COMMAND_WORD + " "
-                        + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindPersonCommand(new NameContainsKeywordsPredicate(keywords)), command);
-    }
+  @Test
+  public void parseCommand_find() throws Exception {
+    List<String> keywords = Arrays.asList("foo", "bar", "baz");
+    FindPersonCommand command = (FindPersonCommand) parser.parseCommand(
+        FindPersonCommand.COMMAND_WORD + " "
+            + keywords.stream().collect(Collectors.joining(" ")));
+    assertEquals(new FindPersonCommand(new NameContainsKeywordsPredicate(keywords)), command);
+  }
 
-    @Test
-    public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
-    }
+  @Test
+  public void parseCommand_help() throws Exception {
+    assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+    assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+  }
 
-    @Test
-    public void parseCommand_mark() throws Exception {
-        final NusNet nusNet = new NusNet("e1234567");
-        final WeekNumber weekNumber = new WeekNumber("10");
-        MarkAttendanceCommand command = (MarkAttendanceCommand) parser.parseCommand(
-                MarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
-                        + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
-        assertEquals(new MarkAttendanceCommand(nusNet, weekNumber), command);
-    }
+  @Test
+  public void parseCommand_mark() throws Exception {
+    final NusNet nusNet = new NusNet("e1234567");
+    final WeekNumber weekNumber = new WeekNumber("10");
+    MarkAttendanceCommand command = (MarkAttendanceCommand) parser.parseCommand(
+        MarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
+            + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
+    assertEquals(new MarkAttendanceCommand(nusNet, weekNumber), command);
+  }
 
-    @Test
-    public void parseCommand_unmark() throws Exception {
-        final NusNet nusNet = new NusNet("e1234567");
-        final WeekNumber weekNumber = new WeekNumber("10");
-        UnmarkAttendanceCommand command = (UnmarkAttendanceCommand) parser.parseCommand(
-                UnmarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
-                        + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
-        assertEquals(new UnmarkAttendanceCommand(nusNet, weekNumber), command);
-    }
+  @Test
+  public void parseCommand_unmark() throws Exception {
+    final NusNet nusNet = new NusNet("e1234567");
+    final WeekNumber weekNumber = new WeekNumber("10");
+    UnmarkAttendanceCommand command = (UnmarkAttendanceCommand) parser.parseCommand(
+        UnmarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
+            + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
+    assertEquals(new UnmarkAttendanceCommand(nusNet, weekNumber), command);
+  }
 
-    @Test
-    public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
-        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
-    }
+  @Test
+  public void parseCommand_list() throws Exception {
+    assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
+    assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
+  }
 
-    @Test
-    public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
-    }
+  @Test
+  public void parseCommand_unrecognisedInput_throwsParseException() {
+    assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
+        () -> parser.parseCommand(""));
+  }
 
-    @Test
-    public void parseCommand_setCourse() throws Exception {
-        final String code = VALID_COURSE_CODE_CS2103T;
-        SetCourseCommand command = (SetCourseCommand) parser.parseCommand(SetCourseCommand.COMMAND_WORD + " "
-                 + code);
-        assertEquals(new SetCourseCommand(new Course(code)), command);
-    }
+  @Test
+  public void parseCommand_setCourse() throws Exception {
+    final String code = VALID_COURSE_CODE_CS2103T;
+    SetCourseCommand command = (SetCourseCommand) parser.parseCommand(SetCourseCommand.COMMAND_WORD + " "
+        + code);
+    assertEquals(new SetCourseCommand(new Course(code)), command);
+  }
 
-    @Test
-    public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
-                parser.parseCommand("unknownCommand"));
-    }
+  @Test
+  public void parseCommand_unknownCommand_throwsParseException() {
+    assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+  }
 
-    /**
-     * Tests that the parser returns the correct AutoComplete object.
-     */
-    @Test
-    void parseAutoComplete() {
-        // No input
-        AutoComplete ac = parser.parseAutoComplete("");
-        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+  /**
+   * Tests that the parser returns the correct AutoComplete object.
+   */
+  @Test
+  void parseAutoComplete() {
+    // No input
+    AutoComplete ac = parser.parseAutoComplete("");
+    assertEquals(ac.getAutoComplete("arbitrary_input"), "");
 
-        // Test for input that contains only command word and no arguments
-        assert(parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
+    // Test for input that contains only command word and no arguments
+    assert (parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
 
-        // Test for input that contains command word and arguments
-        ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
-        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
-    }
+    // Test for input that contains command word and arguments
+    ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
+    assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+  }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -44,117 +44,121 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-  private final AddressBookParser parser = new AddressBookParser();
+    private final AddressBookParser parser = new AddressBookParser();
 
-  @Test
-  public void parseCommand_add() throws Exception {
-    Person person = new PersonBuilder().build();
-    AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-    assertEquals(new AddPersonCommand(person), command);
-  }
+    @Test
+    public void parseCommand_add() throws Exception {
+        Person person = new PersonBuilder().build();
+        AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+        assertEquals(new AddPersonCommand(person), command);
+    }
 
-  @Test
-  public void parseCommand_clear() throws Exception {
-    assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-    assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
-  }
+    @Test
+    public void parseCommand_clear() throws Exception {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    }
 
-  @Test
-  public void parseCommand_delete() throws Exception {
-    DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
-        DeletePersonCommand.COMMAND_WORD + " " + CommandTestUtil.VALID_NUSNET_AMY);
-    assertEquals(new DeletePersonCommand(new NusNet(CommandTestUtil.VALID_NUSNET_AMY)), command);
-  }
+    @Test
+    public void parseCommand_delete() throws Exception {
+        DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
+            DeletePersonCommand.COMMAND_WORD + " " + CommandTestUtil.VALID_NUSNET_AMY);
+        assertEquals(new DeletePersonCommand(new NusNet(CommandTestUtil.VALID_NUSNET_AMY)), command);
+    }
 
-  @Test
-  public void parseCommand_edit() throws Exception {
-    Person person = new PersonBuilder().build();
-    EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-    EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD
-        + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-    assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
-  }
+    @Test
+    public void parseCommand_edit() throws Exception {
+        Person person = new PersonBuilder().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
+        EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD
+            + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
 
-  @Test
-  public void parseCommand_exit() throws Exception {
-    assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-    assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
-  }
+    @Test
+    public void parseCommand_exit() throws Exception {
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
 
-  @Test
-  public void parseCommand_find() throws Exception {
-    List<String> keywords = Arrays.asList("foo", "bar", "baz");
-    FindPersonCommand command = (FindPersonCommand) parser.parseCommand(
-        FindPersonCommand.COMMAND_WORD + " "
-            + keywords.stream().collect(Collectors.joining(" ")));
-    assertEquals(new FindPersonCommand(new NameContainsKeywordsPredicate(keywords)), command);
-  }
+    @Test
+    public void parseCommand_find() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindPersonCommand command = (FindPersonCommand) parser.parseCommand(
+            FindPersonCommand.COMMAND_WORD + " "
+                + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindPersonCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
 
-  @Test
-  public void parseCommand_help() throws Exception {
-    assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-    assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
-  }
+    @Test
+    public void parseCommand_help() throws Exception {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
 
-  @Test
-  public void parseCommand_mark() throws Exception {
-    final NusNet nusNet = new NusNet("e1234567");
-    final WeekNumber weekNumber = new WeekNumber("10");
-    MarkAttendanceCommand command = (MarkAttendanceCommand) parser.parseCommand(
-        MarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
-            + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
-    assertEquals(new MarkAttendanceCommand(nusNet, weekNumber), command);
-  }
+    @Test
+    public void parseCommand_mark() throws Exception {
+        final NusNet nusNet = new NusNet("e1234567");
+        final WeekNumber weekNumber = new WeekNumber("10");
+        MarkAttendanceCommand command = (MarkAttendanceCommand) parser.parseCommand(
+            MarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
+                + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
+        assertEquals(new MarkAttendanceCommand(nusNet, weekNumber), command);
+    }
 
-  @Test
-  public void parseCommand_unmark() throws Exception {
-    final NusNet nusNet = new NusNet("e1234567");
-    final WeekNumber weekNumber = new WeekNumber("10");
-    UnmarkAttendanceCommand command = (UnmarkAttendanceCommand) parser.parseCommand(
-        UnmarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
-            + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
-    assertEquals(new UnmarkAttendanceCommand(nusNet, weekNumber), command);
-  }
+    @Test
+    public void parseCommand_unmark() throws Exception {
+        final NusNet nusNet = new NusNet("e1234567");
+        final WeekNumber weekNumber = new WeekNumber("10");
+        UnmarkAttendanceCommand command = (UnmarkAttendanceCommand) parser.parseCommand(
+            UnmarkAttendanceCommand.COMMAND_WORD + " " + PREFIX_NUSNET
+                + nusNet.value + " " + PREFIX_WEEK + weekNumber.value);
+        assertEquals(new UnmarkAttendanceCommand(nusNet, weekNumber), command);
+    }
 
-  @Test
-  public void parseCommand_list() throws Exception {
-    assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
-    assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
-  }
+    @Test
+    public void parseCommand_list() throws Exception {
+        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
+        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
+    }
 
-  @Test
-  public void parseCommand_unrecognisedInput_throwsParseException() {
-    assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-        () -> parser.parseCommand(""));
-  }
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+            -> parser.parseCommand(""));
+    }
 
-  @Test
-  public void parseCommand_setCourse() throws Exception {
-    final String code = VALID_COURSE_CODE_CS2103T;
-    SetCourseCommand command = (SetCourseCommand) parser.parseCommand(SetCourseCommand.COMMAND_WORD + " "
-        + code);
-    assertEquals(new SetCourseCommand(new Course(code)), command);
-  }
+    @Test
+    public void parseCommand_setCourse() throws Exception {
+        final String code = VALID_COURSE_CODE_CS2103T;
+        SetCourseCommand command = (SetCourseCommand) parser.parseCommand(SetCourseCommand.COMMAND_WORD + " "
+            + code);
+        assertEquals(new SetCourseCommand(new Course(code)), command);
+    }
 
-  @Test
-  public void parseCommand_unknownCommand_throwsParseException() {
-    assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
-  }
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
 
-  /**
-   * Tests that the parser returns the correct AutoComplete object.
-   */
-  @Test
-  void parseAutoComplete() {
-    // No input
-    AutoComplete ac = parser.parseAutoComplete("");
-    assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+    /**
+     * Tests that the parser returns the correct AutoComplete object.
+     */
+    @Test
+    void parseAutoComplete() {
+        // No input
+        AutoComplete ac = parser.parseAutoComplete("");
+        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
 
-    // Test for input that contains only command word and no arguments
-    assert (parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
+        // Test for input that contains only command word and no arguments
+        assert (parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
 
-    // Test for input that contains command word and arguments
-    ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
-    assertEquals(ac.getAutoComplete("arbitrary_input"), "");
-  }
+        // Test for input that contains command word and arguments
+        ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
+        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+
+        // Test for input that contains NUSNET ID
+        ac = parser.parseAutoComplete("arbitrary_command nn/arbitrary_arguments");
+        assert (ac instanceof AutoCompleteNusNetId);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -151,14 +151,14 @@ public class AddressBookParserTest {
         assertEquals(ac.getAutoComplete("arbitrary_input"), "");
 
         // Test for input that contains only command word and no arguments
-        assert (parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
+        assert(parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
 
         // Test for input that contains command word and arguments
         ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
         assertEquals(ac.getAutoComplete("arbitrary_input"), "");
 
         // Test for input that contains NUSNET ID
-        ac = parser.parseAutoComplete("arbitrary_command nn/arbitrary_arguments");
+        ac = parser.parseAutoComplete("arbitrary_command nn/arbitrary_nusnet_id");
         assert (ac instanceof AutoCompleteNusNetId);
     }
 }


### PR DESCRIPTION
### Changes
- [X] Press tab after nn/* to autocomplete nusnet id, if a match exists

### Example
```
addstu nn/e1 // before
// press <tab>
addstu nn/e1234567 //after
```

### Screenshots
- No visible UI changes, just quality of life enhancement

Resolves #72 