### PR TITLE
fix: Fix markdown issue in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -96,8 +96,7 @@ The sequence diagram below illustrates the interactions within the `Logic` compo
 e1234567")` API 
 call as an example.
 
-<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delstu e1234567` 
-Command" />
+<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delstu e1234567` Command" />
 
 <box type="info" seamless>
 


### PR DESCRIPTION
Fix a markdown formatting issue in the developer guide that causes this issue: #78.

Resolves: #78