### PR TITLE
feat: Improve result display UI

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,6 +1,9 @@
 package seedu.address.logic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -26,6 +29,22 @@ public class Messages {
     public static final String MESSAGE_UNMARKED_ATTENDANCE_SUCCESS = "Unmarked attendance for student: ";
     public static final String MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS =
             "Attendance is unmarked for student: ";
+
+    private static final String[] ERROR_MESSAGES = {
+        MESSAGE_UNKNOWN_COMMAND,
+        MESSAGE_INVALID_COMMAND_FORMAT,
+        MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+        MESSAGE_MISSING_NUSNET,
+        MESSAGE_DUPLICATE_FIELDS,
+    };
+
+    private static final String[] SUCCESS_MESSAGES = {
+        MESSAGE_PERSONS_LISTED_OVERVIEW,
+        MESSAGE_MARKED_ATTENDANCE_SUCCESS,
+        MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS,
+        MESSAGE_UNMARKED_ATTENDANCE_SUCCESS,
+        MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS,
+    };
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -63,4 +82,36 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Returns true if the message is a message representing the failure of a command.
+     */
+    public static boolean isErrorMessage(String message) {
+        requireNonNull(message);
+        return Arrays
+                .stream(ERROR_MESSAGES)
+                .map(Messages::stripMessagePlaceholders)
+                .anyMatch(message::contains);
+    }
+
+    /**
+     * Returns true if the message is a message representing the success of a command.
+     */
+    public static boolean isSuccessMessage(String message) {
+        requireNonNull(message);
+        return Arrays
+                .stream(SUCCESS_MESSAGES)
+                .map(Messages::stripMessagePlaceholders)
+                .anyMatch(message::contains);
+    }
+
+    /**
+     * Strips whitespace and {@code %1$s} placeholders from the message.
+     */
+    private static String stripMessagePlaceholders(String message) {
+        if (message.contains("%1$s")) {
+            return String.format(message, "").trim();
+        } else {
+            return message.trim();
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
@@ -86,7 +86,7 @@ public class CommandMessageUsageUtil {
      */
     public static boolean isUtilLabel(String text) {
         requireNonNull(text);
-        return EXAMPLE_LABEL.trim().equals(text.trim())
-                || PARAMETER_LABEL.trim().equals(text.trim());
+        return EXAMPLE_LABEL.strip().equals(text.strip())
+                || PARAMETER_LABEL.strip().equals(text.strip());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
@@ -1,11 +1,16 @@
 package seedu.address.logic.commands.util;
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * A container for {@code Command} specific utility functions.
- * <p>
- *
+ * A container for {@code Command} message specific utility functions.
  */
 public class CommandMessageUsageUtil {
+
+    public static final String EXAMPLE_LABEL = "Example: ";
+
+    public static final String PARAMETER_LABEL = "Parameters: ";
+
     /**
      * Generates the message usage, given the {@code commandWord}, {@code description},
      * and {@code example} as strings.
@@ -14,7 +19,7 @@ public class CommandMessageUsageUtil {
                                               String example) {
         return commandWord + ": "
                 + description + "\n"
-                + "Example: " + example;
+                + EXAMPLE_LABEL + example;
     }
 
     /**
@@ -25,8 +30,8 @@ public class CommandMessageUsageUtil {
                                               String parameters, String example) {
         return commandWord + ": "
                 + description + "\n"
-                + "Parameters: " + parameters + "\n"
-                + "Example: " + example;
+                + PARAMETER_LABEL + parameters + "\n"
+                + EXAMPLE_LABEL + example;
     }
 
     /**
@@ -74,5 +79,14 @@ public class CommandMessageUsageUtil {
         }
 
         return stringBuilder.toString().trim();
+    }
+
+    /**
+     * Returns true if the text is {@link #EXAMPLE_LABEL} or {@link #PARAMETER_LABEL}.
+     */
+    public static boolean isUtilLabel(String text) {
+        requireNonNull(text);
+        return EXAMPLE_LABEL.trim().equals(text.trim())
+                || PARAMETER_LABEL.trim().equals(text.trim());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/util/CommandWordUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandWordUtil.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeletePersonCommand;
+import seedu.address.logic.commands.EditPersonCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindPersonCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListPersonCommand;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.SetCourseCommand;
+import seedu.address.logic.commands.UnmarkAttendanceCommand;
+
+/**
+ * A container for {@code Command} word specific utility functions.
+ */
+public class CommandWordUtil {
+    private static final String[] ALL_COMMAND_WORDS = {
+        AddPersonCommand.COMMAND_WORD,
+        ClearCommand.COMMAND_WORD,
+        DeletePersonCommand.COMMAND_WORD,
+        EditPersonCommand.COMMAND_WORD,
+        ExitCommand.COMMAND_WORD,
+        FindPersonCommand.COMMAND_WORD,
+        HelpCommand.COMMAND_WORD,
+        ListPersonCommand.COMMAND_WORD,
+        MarkAttendanceCommand.COMMAND_WORD,
+        SetCourseCommand.COMMAND_WORD,
+        UnmarkAttendanceCommand.COMMAND_WORD,
+    };
+
+    /**
+     * Returns true if the word is a command word, after removing non-word characters.
+     */
+    public static boolean isCommandWord(String word) {
+        requireNonNull(word);
+        String strippedWord = word.replaceAll("\\W", "");
+        return Arrays
+                .asList(ALL_COMMAND_WORDS)
+                .contains(strippedWord);
+    }
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static seedu.address.ui.util.SyntaxHighlighter.ERROR_STYLE_CLASS;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
@@ -15,7 +17,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class CommandBox extends UiPart<Region> {
 
-    public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -10,6 +10,7 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
@@ -169,6 +170,10 @@ public class MainWindow extends UiPart<Stage> {
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
+
+        // Use preference height to prevent children from overflowing.
+        resultDisplayPlaceholder.setMaxHeight(Region.USE_PREF_SIZE);
+        resultDisplayPlaceholder.setMinHeight(Region.USE_PREF_SIZE);
 
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -2,9 +2,13 @@ package seedu.address.ui;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import javafx.fxml.FXML;
-import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import seedu.address.ui.util.SyntaxHighlighter;
 
 /**
  * A ui for the status bar that is displayed at the header of the application.
@@ -14,7 +18,7 @@ public class ResultDisplay extends UiPart<Region> {
     private static final String FXML = "ResultDisplay.fxml";
 
     @FXML
-    private TextArea resultDisplay;
+    private VBox resultDisplay;
 
     public ResultDisplay() {
         super(FXML);
@@ -22,7 +26,12 @@ public class ResultDisplay extends UiPart<Region> {
 
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
-        resultDisplay.setText(feedbackToUser);
-    }
 
+        resultDisplay.getChildren().setAll(Arrays
+                .stream(feedbackToUser.split("\\n"))
+                .map(String::strip)
+                .map(line -> SyntaxHighlighter.generateLine(line, "result-display"))
+                .collect(Collectors.toList())
+        );
+    }
 }

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -16,6 +16,7 @@ import seedu.address.ui.util.SyntaxHighlighter;
 public class ResultDisplay extends UiPart<Region> {
 
     private static final String FXML = "ResultDisplay.fxml";
+    private static final SyntaxHighlighter resultSyntax = new SyntaxHighlighter("result-display");
 
     @FXML
     private VBox resultDisplay;
@@ -30,7 +31,7 @@ public class ResultDisplay extends UiPart<Region> {
         resultDisplay.getChildren().setAll(Arrays
                 .stream(feedbackToUser.split("\\n"))
                 .map(String::strip)
-                .map(line -> SyntaxHighlighter.generateLine(line, "result-display"))
+                .map(resultSyntax::generateLine)
                 .collect(Collectors.toList())
         );
     }

--- a/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
+++ b/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
@@ -17,6 +17,17 @@ public class SyntaxHighlighter {
     public static final String ERROR_STYLE_CLASS = "error";
     public static final String SUCCESS_STYLE_CLASS = "success";
 
+    private final String[] styleClasses;
+
+    /**
+     * Creates a SyntaxHighlighter with default style classes to apply.
+     *
+     * @param styleClasses The style classes to add into rich-text formatting.
+     */
+    public SyntaxHighlighter(String... styleClasses) {
+        this.styleClasses = styleClasses;
+    }
+
     /**
      * Generates a rich-text line with basic syntax highlighting applied to it.
      * <p>
@@ -26,25 +37,24 @@ public class SyntaxHighlighter {
      * <li><font color="#8AB68D">Success message highlighting</font>
      *
      * @param line The line of text to generate from.
-     * @param styleClasses The style classes to add into the rich-text.
      * @return The generated rich-text with formatting applied.
      */
-    public static TextFlow generateLine(String line, String... styleClasses) {
+    public TextFlow generateLine(String line) {
         if (isErrorMessage(line)) {
-            return generateErrorLine(line, styleClasses);
+            return generateErrorLine(line);
         }
 
         if (isSuccessMessage(line)) {
-            return generateSuccessLine(line, styleClasses);
+            return generateSuccessLine(line);
         }
 
-        return generateGenericLine(line, styleClasses);
+        return generateGenericLine(line);
     }
 
     /**
      * Generates a rich-text line with error formatting applied.
      */
-    private static TextFlow generateErrorLine(String errorMessage, String... styleClasses) {
+    private TextFlow generateErrorLine(String errorMessage) {
         Text errorText = new Text(errorMessage);
         errorText.getStyleClass().addAll(styleClasses);
         errorText.getStyleClass().addAll(ERROR_STYLE_CLASS, BOLD_STYLE_CLASS);
@@ -55,7 +65,7 @@ public class SyntaxHighlighter {
     /**
      * Generates a rich-text line with success formatting applied.
      */
-    private static TextFlow generateSuccessLine(String successMessage, String... styleClasses) {
+    private TextFlow generateSuccessLine(String successMessage) {
         Text successText = new Text(successMessage);
         successText.getStyleClass().addAll(styleClasses);
         successText.getStyleClass().addAll(SUCCESS_STYLE_CLASS, BOLD_STYLE_CLASS);
@@ -66,12 +76,12 @@ public class SyntaxHighlighter {
     /**
      * Generates a rich-text line with formatting applied.
      */
-    private static TextFlow generateGenericLine(String genericMessage, String... styleClasses) {
+    private TextFlow generateGenericLine(String genericMessage) {
         String[] messageWords = genericMessage.split(" ");
         Node[] generatedNodes = new Node[messageWords.length * 2 - 1];
 
         for (int j = 0, i = 0; i < messageWords.length && j < generatedNodes.length; i++) {
-            generatedNodes[j++] = generateGenericWord(messageWords[i], styleClasses);
+            generatedNodes[j++] = generateGenericWord(messageWords[i]);
             if (j < generatedNodes.length) {
                 generatedNodes[j++] = generateSingleSpace();
             }
@@ -83,7 +93,7 @@ public class SyntaxHighlighter {
     /**
      * Generates a rich-text word with formatting applied.
      */
-    private static Text generateGenericWord(String word, String... styleClasses) {
+    private Text generateGenericWord(String word) {
         Text wordText = new Text(word);
         wordText.getStyleClass().addAll(styleClasses);
 

--- a/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
+++ b/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
@@ -55,8 +55,7 @@ public class SyntaxHighlighter {
      * Generates a rich-text line with error formatting applied.
      */
     private TextFlow generateErrorLine(String errorMessage) {
-        Text errorText = new Text(errorMessage);
-        errorText.getStyleClass().addAll(styleClasses);
+        Text errorText = generateDefaultStyleText(errorMessage);
         errorText.getStyleClass().addAll(ERROR_STYLE_CLASS, BOLD_STYLE_CLASS);
 
         return new TextFlow(errorText);
@@ -66,8 +65,7 @@ public class SyntaxHighlighter {
      * Generates a rich-text line with success formatting applied.
      */
     private TextFlow generateSuccessLine(String successMessage) {
-        Text successText = new Text(successMessage);
-        successText.getStyleClass().addAll(styleClasses);
+        Text successText = generateDefaultStyleText(successMessage);
         successText.getStyleClass().addAll(SUCCESS_STYLE_CLASS, BOLD_STYLE_CLASS);
 
         return new TextFlow(successText);
@@ -94,18 +92,34 @@ public class SyntaxHighlighter {
      * Generates a rich-text word with formatting applied.
      */
     private Text generateGenericWord(String word) {
-        Text wordText = new Text(word);
-        wordText.getStyleClass().addAll(styleClasses);
+        Text wordText = generateDefaultStyleText(word);
+
+        if (word.isBlank()) {
+            return wordText;
+        }
 
         // Bold keywords
-        if (isUtilLabel(word) || isCommandWord(word)) {
+        if (isKeyword(word)) {
             wordText.getStyleClass().add(BOLD_STYLE_CLASS);
         }
 
         return wordText;
     }
 
-    private static Text generateSingleSpace() {
-        return new Text(" ");
+    /**
+     * Generates rich-text with the default styles applied to it, from a piece of text.
+     */
+    private Text generateDefaultStyleText(String text) {
+        Text styledText = new Text(text);
+        styledText.getStyleClass().addAll(styleClasses);
+        return styledText;
+    }
+
+    private Text generateSingleSpace() {
+        return generateDefaultStyleText(" ");
+    }
+
+    private boolean isKeyword(String text) {
+        return text.endsWith(":") && (isUtilLabel(text) || isCommandWord(text));
     }
 }

--- a/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
+++ b/src/main/java/seedu/address/ui/util/SyntaxHighlighter.java
@@ -1,0 +1,101 @@
+package seedu.address.ui.util;
+
+import static seedu.address.logic.Messages.isErrorMessage;
+import static seedu.address.logic.Messages.isSuccessMessage;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.isUtilLabel;
+import static seedu.address.logic.commands.util.CommandWordUtil.isCommandWord;
+
+import javafx.scene.Node;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+/**
+ * Container for methods regarding the highlighting of syntax.
+ */
+public class SyntaxHighlighter {
+    public static final String BOLD_STYLE_CLASS = "bold";
+    public static final String ERROR_STYLE_CLASS = "error";
+    public static final String SUCCESS_STYLE_CLASS = "success";
+
+    /**
+     * Generates a rich-text line with basic syntax highlighting applied to it.
+     * <p>
+     * The formatting applied includes:
+     * <li><b>Bolding of keywords</b>
+     * <li><font color="#d06651">Error message highlighting</font>
+     * <li><font color="#8AB68D">Success message highlighting</font>
+     *
+     * @param line The line of text to generate from.
+     * @param styleClasses The style classes to add into the rich-text.
+     * @return The generated rich-text with formatting applied.
+     */
+    public static TextFlow generateLine(String line, String... styleClasses) {
+        if (isErrorMessage(line)) {
+            return generateErrorLine(line, styleClasses);
+        }
+
+        if (isSuccessMessage(line)) {
+            return generateSuccessLine(line, styleClasses);
+        }
+
+        return generateGenericLine(line, styleClasses);
+    }
+
+    /**
+     * Generates a rich-text line with error formatting applied.
+     */
+    private static TextFlow generateErrorLine(String errorMessage, String... styleClasses) {
+        Text errorText = new Text(errorMessage);
+        errorText.getStyleClass().addAll(styleClasses);
+        errorText.getStyleClass().addAll(ERROR_STYLE_CLASS, BOLD_STYLE_CLASS);
+
+        return new TextFlow(errorText);
+    }
+
+    /**
+     * Generates a rich-text line with success formatting applied.
+     */
+    private static TextFlow generateSuccessLine(String successMessage, String... styleClasses) {
+        Text successText = new Text(successMessage);
+        successText.getStyleClass().addAll(styleClasses);
+        successText.getStyleClass().addAll(SUCCESS_STYLE_CLASS, BOLD_STYLE_CLASS);
+
+        return new TextFlow(successText);
+    }
+
+    /**
+     * Generates a rich-text line with formatting applied.
+     */
+    private static TextFlow generateGenericLine(String genericMessage, String... styleClasses) {
+        String[] messageWords = genericMessage.split(" ");
+        Node[] generatedNodes = new Node[messageWords.length * 2 - 1];
+
+        for (int j = 0, i = 0; i < messageWords.length && j < generatedNodes.length; i++) {
+            generatedNodes[j++] = generateGenericWord(messageWords[i], styleClasses);
+            if (j < generatedNodes.length) {
+                generatedNodes[j++] = generateSingleSpace();
+            }
+        }
+
+        return new TextFlow(generatedNodes);
+    }
+
+    /**
+     * Generates a rich-text word with formatting applied.
+     */
+    private static Text generateGenericWord(String word, String... styleClasses) {
+        Text wordText = new Text(word);
+        wordText.getStyleClass().addAll(styleClasses);
+
+        // Bold keywords
+        if (isUtilLabel(word) || isCommandWord(word)) {
+            wordText.getStyleClass().add(BOLD_STYLE_CLASS);
+        }
+
+        return wordText;
+    }
+
+    private static Text generateSingleSpace() {
+        return new Text(" ");
+    }
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -151,6 +151,13 @@
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
     -fx-text-fill: white;
+    -fx-fill: white;
+    -fx-line-spacing: 0px;
+    -fx-font-smoothing-type: lcd;
+}
+
+.result-display .bold {
+    -fx-font-family: "Segoe UI Bold" !important;
 }
 
 .result-display .label {

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -1,6 +1,13 @@
-
+/* The error class should always override the default text-fill style */
 .error {
-    -fx-text-fill: #d06651 !important; /* The error class should always override the default text-fill style */
+    -fx-text-fill: #d06651 !important;
+    -fx-fill: #d06651 !important;
+}
+
+ /* The success class should always override the default text-fill style */
+.success {
+    -fx-text-fill: #8AB68D !important;
+    -fx-fill: #8AB68D !important;
 }
 
 .list-cell:empty {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -39,7 +39,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   alignment="TOP_LEFT">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.TextArea?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.text.TextFlow?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.layout.VBox?>
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+           xmlns:fx="http://javafx.com/fxml/1" alignment="TOP_LEFT">
+  <VBox fx:id="resultDisplay" styleClass="result-display" spacing="5">
+    <padding>
+      <Insets top="5" right="5" bottom="5" left="5" />
+    </padding>
+    <TextFlow>
+      <Text/>
+    </TextFlow>
+  </VBox>
 </StackPane>

--- a/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,5 +67,17 @@ class CommandMessageUsageUtilTest {
                 p2.asOptional(true)
         );
         assertEquals("TEM hic/741", example);
+    }
+
+    @Test
+    void isUtilLabel_true() {
+        assertTrue(CommandMessageUsageUtil.isUtilLabel(CommandMessageUsageUtil.EXAMPLE_LABEL));
+        assertTrue(CommandMessageUsageUtil.isUtilLabel(CommandMessageUsageUtil.PARAMETER_LABEL));
+    }
+
+    @Test
+    void isUtilLabel_false() {
+        assertFalse(CommandMessageUsageUtil.isUtilLabel(""));
+        assertFalse(CommandMessageUsageUtil.isUtilLabel("abc"));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/util/CommandWordUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandWordUtilTest.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CommandWordUtilTest {
+
+    @Test
+    void isCommandWord_true() {
+        assertTrue(CommandWordUtil.isCommandWord("list"));
+    }
+
+    @Test
+    void isCommandWord_false() {
+        assertFalse(CommandWordUtil.isCommandWord("abc"));
+    }
+}

--- a/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
+++ b/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.util.CommandWordUtil.isCommandWord;
 import static seedu.address.ui.util.SyntaxHighlighter.BOLD_STYLE_CLASS;
 import static seedu.address.ui.util.SyntaxHighlighter.ERROR_STYLE_CLASS;
 import static seedu.address.ui.util.SyntaxHighlighter.SUCCESS_STYLE_CLASS;
-import static seedu.address.ui.util.SyntaxHighlighter.generateLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,12 +23,15 @@ class SyntaxHighlighterTest {
     private TextFlow errorTextFlow;
     private TextFlow successTextFlow;
     private TextFlow genericTextFlow;
+
     @BeforeEach
     void setUp() {
-        errorTextFlow = generateLine(Messages.MESSAGE_UNKNOWN_COMMAND);
-        successTextFlow = generateLine(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
-        genericTextFlow = generateLine(MarkAttendanceCommand.MESSAGE_USAGE);
+        SyntaxHighlighter s = new SyntaxHighlighter();
+        errorTextFlow = s.generateLine(Messages.MESSAGE_UNKNOWN_COMMAND);
+        successTextFlow = s.generateLine(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
+        genericTextFlow = s.generateLine(MarkAttendanceCommand.MESSAGE_USAGE);
     }
+
     @Test
     void generateLine_errorLine_singleText() {
         ObservableList<Node> nodes = errorTextFlow.getChildren();

--- a/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
+++ b/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
@@ -78,7 +78,7 @@ class SyntaxHighlighterTest {
                 Text text = (Text) node;
                 String content = text.getText();
                 assertEquals(
-                        isUtilLabel(content) || isCommandWord(content),
+                        content.endsWith(":") && (isUtilLabel(content) || isCommandWord(content)),
                         text.getStyleClass().contains(BOLD_STYLE_CLASS)
                 );
             }

--- a/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
+++ b/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
@@ -1,0 +1,96 @@
+package seedu.address.ui.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.util.CommandMessageUsageUtil.isUtilLabel;
+import static seedu.address.logic.commands.util.CommandWordUtil.isCommandWord;
+import static seedu.address.ui.util.SyntaxHighlighter.BOLD_STYLE_CLASS;
+import static seedu.address.ui.util.SyntaxHighlighter.ERROR_STYLE_CLASS;
+import static seedu.address.ui.util.SyntaxHighlighter.SUCCESS_STYLE_CLASS;
+import static seedu.address.ui.util.SyntaxHighlighter.generateLine;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+
+class SyntaxHighlighterTest {
+    private TextFlow errorTextFlow;
+    private TextFlow successTextFlow;
+    private TextFlow genericTextFlow;
+    @BeforeEach
+    void setUp() {
+        errorTextFlow = generateLine(Messages.MESSAGE_UNKNOWN_COMMAND);
+        successTextFlow = generateLine(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
+        genericTextFlow = generateLine(MarkAttendanceCommand.MESSAGE_USAGE);
+    }
+    @Test
+    void generateLine_errorLine_singleText() {
+        ObservableList<Node> nodes = errorTextFlow.getChildren();
+        assertEquals(1, nodes.size());
+    }
+
+    @Test
+    void generateLine_errorLine_errorFormat() {
+        Node node = errorTextFlow.getChildren().get(0);
+        if (node instanceof Text) {
+            Text text = (Text) node;
+            assertTrue(text.getStyleClass().contains(ERROR_STYLE_CLASS));
+            assertTrue(text.getStyleClass().contains(BOLD_STYLE_CLASS));
+        }
+    }
+
+    @Test
+    void generateLine_successLine_singleText() {
+        ObservableList<Node> nodes = successTextFlow.getChildren();
+        assertEquals(1, nodes.size());
+    }
+
+    @Test
+    void generateLine_successLine_successFormat() {
+        Node node = successTextFlow.getChildren().get(0);
+        if (node instanceof Text) {
+            Text text = (Text) node;
+            assertTrue(text.getStyleClass().contains(SUCCESS_STYLE_CLASS));
+            assertTrue(text.getStyleClass().contains(BOLD_STYLE_CLASS));
+        }
+    }
+
+    @Test
+    void generateLine_genericLine_childrenText() {
+        for (Node node : genericTextFlow.getChildren()) {
+            assertTrue(node instanceof Text);
+        }
+    }
+
+    @Test
+    void generateLine_genericLine_keywordsBold() {
+        for (Node node : genericTextFlow.getChildren()) {
+            if (node instanceof Text) {
+                Text text = (Text) node;
+                String content = text.getText();
+                assertEquals(
+                        isUtilLabel(content) || isCommandWord(content),
+                        text.getStyleClass().contains(BOLD_STYLE_CLASS)
+                );
+            }
+        }
+    }
+
+    @Test
+    void generateLine_genericLine_noInvalidFormats() {
+        for (Node node : genericTextFlow.getChildren()) {
+            if (node instanceof Text) {
+                Text text = (Text) node;
+                assertFalse(text.getStyleClass().contains(ERROR_STYLE_CLASS));
+                assertFalse(text.getStyleClass().contains(SUCCESS_STYLE_CLASS));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What's changed
Improve the UI of the result display.
* No more scrollbar in the result display.
* Text is wrapped so that no scrolling is necessary, which fits our user better.
* Basic syntax highlighting makes the results easier to read. 
  * I decided to add this along with the other changes as it helps improve the quality of existing features. 
  * Syntax highlighting has been implemented in an extensible way, if there is a need to apply it to other things.

>[!IMPORTANT]
>By using `TextFlow` with `Text` instead of `TextArea`, the functionality of copying text from the result display is gone, as only `TextArea` supports copying, but the others do not. However, this should not impact the user much, due to the [typing preference constraint](https://nus-cs2103-ay2324s2.github.io/website/admin/tp-constraints.html#constraint-typing-preferred), as users would prefer to type out rather than copy paste the example from the result display.

## UI screenshots

>[!NOTE]
>Syntax highlighting for success messages.
>* Note that the success message is bolded
>* Bolding is done via a font change.
>
>![Screenshot 2024-03-27 191710](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/a681f154-6d9b-4b49-9f1a-00cb97accfed)

>[!NOTE]
>Syntax highlighting for error messages.
>* Keywords (`Parameters`, `Example`, `addstu`) are bolded.
>   * Keywords are bolded only if it ends with a colon
>* Further improvements to syntax highlighting could be by coloring the prefixes in a certain color.
>* Resizing the window works with this, and there is a slight line spacing between each block for better readability.
>   * Instead of using `TextArea`, I used `Text` inside a `TextFlow`, which supports this kind of wrapping by default.
>
>![Screenshot 2024-03-28 135317](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/ff8bd4e1-6a96-41ea-9805-b846c35c0396)


Resolves #38