### PR TITLE
fix: Result messages

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -76,4 +76,20 @@ public class StringUtil {
 
         return a.strip().equals(b.strip());
     }
+
+    /**
+     * Strips whitespace and format specifiers from the {@code message}.
+     * <p>
+     * Format specifiers are assumed to be in the format of {@code %\\d*\\$?\\w}.
+     *
+     * @param text The text to strip.
+     * @return The message without the placeholders and whitespace.
+     */
+    public static String stripMessageFormatSpecifiers(String text) {
+        if (text.contains("%")) {
+            return text.replaceAll("%\\d*\\$?\\w", "").trim();
+        } else {
+            return text.trim();
+        }
+    }
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,15 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if the strings are equal after being trimmed.
+     */
+    public static boolean areStrippedStringsEqual(String a, String b) {
+        if (a == null || b == null) {
+            return a == null && b == null;
+        }
+
+        return a.strip().equals(b.strip());
+    }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -8,6 +8,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeletePersonCommand;
+import seedu.address.logic.commands.EditPersonCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListPersonCommand;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.SetCourseCommand;
+import seedu.address.logic.commands.UnmarkAttendanceCommand;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
@@ -16,20 +26,19 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
+    // These messages are not command-specific, so are listed here
+    // Messages that are command-specific should be in their respective classes
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_MISSING_NUSNET = "No such student with the NUSNET_ID found in contacts!";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_MISSING_NUSNET = "No such student with the NUSNet ID found in contacts!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_MARKED_ATTENDANCE_SUCCESS = "Marked attendance for student: ";
-    public static final String MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS =
-            "Re-marked Attendance for student: ";
-    public static final String MESSAGE_UNMARKED_ATTENDANCE_SUCCESS = "Unmarked attendance for student: ";
-    public static final String MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS =
-            "Attendance is unmarked for student: ";
+            "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "This student already exists in the contact book";
 
+    /** Error messages are shown when a command cannot be executed. */
     private static final String[] ERROR_MESSAGES = {
         MESSAGE_UNKNOWN_COMMAND,
         MESSAGE_INVALID_COMMAND_FORMAT,
@@ -38,12 +47,26 @@ public class Messages {
         MESSAGE_DUPLICATE_FIELDS,
     };
 
-    private static final String[] SUCCESS_MESSAGES = {
+    /** Neutral messages are shown when a command executes successfully, but no change occurs. */
+    private static final String[] NEUTRAL_MESSAGES = {
         MESSAGE_PERSONS_LISTED_OVERVIEW,
-        MESSAGE_MARKED_ATTENDANCE_SUCCESS,
-        MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS,
-        MESSAGE_UNMARKED_ATTENDANCE_SUCCESS,
-        MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS,
+        EditPersonCommand.MESSAGE_NOT_EDITED,
+        ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT,
+        HelpCommand.SHOWING_HELP_MESSAGE,
+        ListPersonCommand.MESSAGE_SUCCESS,
+        MarkAttendanceCommand.MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS,
+        UnmarkAttendanceCommand.MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS
+    };
+
+    /** Success messages are shown when a command executes successfully and does a modification. */
+    private static final String[] SUCCESS_MESSAGES = {
+        AddPersonCommand.MESSAGE_SUCCESS,
+        ClearCommand.MESSAGE_SUCCESS,
+        DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+        MarkAttendanceCommand.MESSAGE_MARKED_ATTENDANCE_SUCCESS,
+        SetCourseCommand.MESSAGE_SUCCESS,
+        UnmarkAttendanceCommand.MESSAGE_UNMARKED_ATTENDANCE_SUCCESS,
     };
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeletePersonCommand;
@@ -23,11 +24,13 @@ import seedu.address.model.person.Person;
 
 /**
  * Container for user visible messages.
+ * <p>
+ * Messages that are not command-specific are listed here.
+ * <p>
+ * Messages that are command-specific should be in their respective classes.
  */
 public class Messages {
 
-    // These messages are not command-specific, so are listed here
-    // Messages that are command-specific should be in their respective classes
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
@@ -106,35 +109,32 @@ public class Messages {
     }
 
     /**
-     * Returns true if the message is a message representing the failure of a command.
+     * Returns true if the {@code message} is a message representing the failure of a command.
+     * Otherwise, false is returned.
+     *
+     * @param message The message to check.
+     * @see StringUtil#stripMessageFormatSpecifiers(String)
      */
     public static boolean isErrorMessage(String message) {
         requireNonNull(message);
         return Arrays
                 .stream(ERROR_MESSAGES)
-                .map(Messages::stripMessagePlaceholders)
+                .map(StringUtil::stripMessageFormatSpecifiers)
                 .anyMatch(message::contains);
     }
 
     /**
-     * Returns true if the message is a message representing the success of a command.
+     * Returns true if the {@code message} is a message representing the success of a command.
+     * Otherwise, false is returned.
+     *
+     * @param message The message to check.
+     * @see StringUtil#stripMessageFormatSpecifiers(String)
      */
     public static boolean isSuccessMessage(String message) {
         requireNonNull(message);
         return Arrays
                 .stream(SUCCESS_MESSAGES)
-                .map(Messages::stripMessagePlaceholders)
+                .map(StringUtil::stripMessageFormatSpecifiers)
                 .anyMatch(message::contains);
-    }
-
-    /**
-     * Strips whitespace and {@code %1$s} placeholders from the message.
-     */
-    private static String stripMessagePlaceholders(String message) {
-        if (message.contains("%1$s")) {
-            return String.format(message, "").trim();
-        } else {
-            return message.trim();
-        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
@@ -24,7 +25,7 @@ public class AddPersonCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Adds a person to the address book. ",
+            "Adds a student into the contact book. ",
             PARAMETER_NAME,
             PARAMETER_NUSNET,
             PARAMETER_PHONE.asOptional(true),
@@ -33,10 +34,9 @@ public class AddPersonCommand extends Command {
             PARAMETER_TAG.asMultiple(2)
     );
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
-    public static final String MESSAGE_DUPLICATE_NUSNET = "Another person with the same NUSNET already exists in the "
-            + "contact book";
+    public static final String MESSAGE_SUCCESS = "New student added: %1$s";
+    public static final String MESSAGE_DUPLICATE_NUSNET = "Another student with the same NUSNet ID "
+            + "already exists in the contact book";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,8 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
+    public static final String MESSAGE_SUCCESS = "Contact book has been cleared!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -22,7 +22,7 @@ public class DeletePersonCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Deletes the student identified by NUSNET_ID.",
+            "Deletes the student identified by NUSNet ID.",
             PARAMETER_NUSNET
     );
 

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -26,7 +26,7 @@ public class DeletePersonCommand extends Command {
             PARAMETER_NUSNET
     );
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted student: %1$s";
 
     private final NusNet targetNusNet;
 

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.logic.commands.util.CommandMessageUsageUtil.generateMessageUsage;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_ADDRESS;
 import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_EMAIL;
@@ -42,8 +43,8 @@ public class EditPersonCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Edits the details of the person identified "
-                    + "by the index number used in the displayed person list. "
+            "Edits the details of the student identified "
+                    + "by the index number used in the currently displayed student list. "
                     + "Existing values will be overwritten by the input values.",
             PARAMETER_INDEX,
             PARAMETER_NAME.asOptional(false),
@@ -54,9 +55,8 @@ public class EditPersonCommand extends Command {
             PARAMETER_TAG.asMultiple(0)
     );
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited student: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -18,11 +18,10 @@ public class FindPersonCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Finds all persons whose names contain any of "
+            "Finds all students whose names contain any of "
                     + "the specified keywords (case-insensitive) and displays them as a list with index numbers.",
             "KEYWORD [MORE_KEYWORDS]...",
             COMMAND_WORD + " alice bob charlie"
-
     );
 
     private final NameContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.weeknumber.WeekNumber;
 
 /**
- * Marks attendance of an existing person in the address book.
+ * Marks attendance of an existing student in the contact book.
  */
 public class MarkAttendanceCommand extends Command {
 
@@ -26,9 +26,13 @@ public class MarkAttendanceCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Marks the attendance of the person identified by their NusNet by adding the specified week to "
-                    + "their attendance set. ",
+            "Marks the attendance of the student identified by their NUSNet ID "
+                    + "by adding the specified week to their attendance set. ",
             PARAMETER_NUSNET, PARAMETER_WEEK);
+
+    public static final String MESSAGE_MARKED_ATTENDANCE_SUCCESS = "Marked attendance for student: ";
+    public static final String MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS =
+            "Attendance is already marked for student: ";
 
     private final NusNet nusNet;
     private final WeekNumber weekNumber;
@@ -59,7 +63,7 @@ public class MarkAttendanceCommand extends Command {
 
         if (!updatedWeekAttendance.add(weekNumber)) {
             String formattedMessage = String.format("%1$s%2$s, %3$s, Week %4$s",
-                    Messages.MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS,
+                    MESSAGE_MARK_EXISTING_ATTENDANCE_SUCCESS,
                     personToMark.getName(), personToMark.getNusNet(), weekNumber);
 
             return new CommandResult(formattedMessage);
@@ -70,7 +74,7 @@ public class MarkAttendanceCommand extends Command {
 
         model.setPerson(personToMark, updatedPerson);
 
-        String formattedMessage = String.format("%1$s%2$s, %3$s, Week %4$s", Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS,
+        String formattedMessage = String.format("%1$s%2$s, %3$s, Week %4$s", MESSAGE_MARKED_ATTENDANCE_SUCCESS,
                 updatedPerson.getName(), updatedPerson.getNusNet(), weekNumber);
 
         return new CommandResult(formattedMessage);

--- a/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
@@ -9,6 +9,8 @@ import seedu.address.logic.commands.util.CommandMessageUsageUtil;
 import seedu.address.model.Model;
 import seedu.address.model.course.Course;
 
+
+
 /**
  * Represents a command to set the current course in the application.
  * This command updates the application's state to reflect the specified course.

--- a/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.util.ParameterSyntax.PARAMETER_COURSE_CODE;
 import static seedu.address.model.course.Course.isValidCode;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -18,14 +19,11 @@ import seedu.address.model.course.Course;
 public class SetCourseCommand extends Command {
     public static final String COMMAND_WORD = "setcrs";
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Course code should follow the format \"XX1234Y\", Y is optional.";
 
     public static final String MESSAGE_USAGE = CommandMessageUsageUtil.generateMessageUsage(
             COMMAND_WORD,
-            "Sets the course name. " + MESSAGE_CONSTRAINTS,
-            "COURSE_CODE",
-            COMMAND_WORD + " CS2104");
+            "Sets the course name. ",
+            PARAMETER_COURSE_CODE);
 
     public static final String MESSAGE_SUCCESS = "Successfully updated course name";
 
@@ -48,7 +46,7 @@ public class SetCourseCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         if (!isValidCode(course.toString())) {
-            throw new CommandException(MESSAGE_CONSTRAINTS);
+            throw new CommandException(PARAMETER_COURSE_CODE.getParameterConstraint());
         }
         model.changeCode(course.toString());
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetCourseCommand.java
@@ -8,8 +8,6 @@ import seedu.address.logic.commands.util.CommandMessageUsageUtil;
 import seedu.address.model.Model;
 import seedu.address.model.course.Course;
 
-
-
 /**
  * Represents a command to set the current course in the application.
  * This command updates the application's state to reflect the specified course.
@@ -20,13 +18,14 @@ import seedu.address.model.course.Course;
 public class SetCourseCommand extends Command {
     public static final String COMMAND_WORD = "setcrs";
 
-    public static final String MESSAGE_ARGUMENTS = "Course: %1$s";
-
     public static final String MESSAGE_CONSTRAINTS =
-            "Course code should follow the format \"XX1234Y\", Y is optional";
+            "Course code should follow the format \"XX1234Y\", Y is optional.";
 
-    public static final String MESSAGE_USAGE = CommandMessageUsageUtil.generateMessageUsage(COMMAND_WORD,
-            "Set Course name ", "course code", COMMAND_WORD + " CS2104");
+    public static final String MESSAGE_USAGE = CommandMessageUsageUtil.generateMessageUsage(
+            COMMAND_WORD,
+            "Sets the course name. " + MESSAGE_CONSTRAINTS,
+            "COURSE_CODE",
+            COMMAND_WORD + " CS2104");
 
     public static final String MESSAGE_SUCCESS = "Successfully updated course name";
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -17,7 +17,10 @@ import seedu.address.model.person.Person;
 import seedu.address.model.weeknumber.WeekNumber;
 
 /**
- * Unmarks attendance of an existing student in the contact book.
+ * Unmarks attendance of an existing student of a certain week in the contact book.
+ * <li>The week should be between 1 and 13.
+ * <li>The NUSNet ID should be valid.
+ * <li>Attendance can be unmarked again, without any error, but no change would occur.
  */
 public class UnmarkAttendanceCommand extends Command {
 
@@ -36,8 +39,10 @@ public class UnmarkAttendanceCommand extends Command {
     private final WeekNumber weekNumber;
 
     /**
-     * @param nusNet of the person to mark attendance for
-     * @param weekNumber the week number to mark attendance for
+     * Creates an {@link UnmarkAttendanceCommand}.
+     *
+     * @param nusNet of the person to mark attendance for.
+     * @param weekNumber the week number to mark attendance for.
      */
     public UnmarkAttendanceCommand(NusNet nusNet, WeekNumber weekNumber) {
         requireNonNull(nusNet);

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.weeknumber.WeekNumber;
 
 /**
- *
+ * Unmarks attendance of an existing student in the contact book.
  */
 public class UnmarkAttendanceCommand extends Command {
 
@@ -25,10 +25,13 @@ public class UnmarkAttendanceCommand extends Command {
 
     public static final String MESSAGE_USAGE = generateMessageUsage(
             COMMAND_WORD,
-            "Unmarks the attendance of the person identified by their NusNet by removing the specified week to "
-                    + "their attendance set. ",
+            "Unmarks the attendance of the student identified by their NUSNet ID "
+                    + "by removing the specified week to their attendance set. ",
             PARAMETER_NUSNET, PARAMETER_WEEK);
 
+    public static final String MESSAGE_UNMARKED_ATTENDANCE_SUCCESS = "Unmarked attendance for student: ";
+    public static final String MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS =
+            "Attendance is already unmarked for student: ";
     private final NusNet nusNet;
     private final WeekNumber weekNumber;
 
@@ -57,7 +60,7 @@ public class UnmarkAttendanceCommand extends Command {
 
         if (!updatedWeekAttendance.remove(weekNumber)) {
             String formattedMessage = String.format("%1$s%2$s, %3$s, Week %4$s",
-                    Messages.MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS,
+                    MESSAGE_UNMARK_NONEXISITING_ATTENDANCE_SUCCESS,
                     personToUnmark.getName(), personToUnmark.getNusNet(), weekNumber);
 
             return new CommandResult(formattedMessage);
@@ -70,7 +73,7 @@ public class UnmarkAttendanceCommand extends Command {
         model.setPerson(personToUnmark, updatedPerson);
 
         String formattedMessage = String.format("%1$s%2$s, %3$s, Week %4$s",
-                Messages.MESSAGE_UNMARKED_ATTENDANCE_SUCCESS,
+                MESSAGE_UNMARKED_ATTENDANCE_SUCCESS,
                 updatedPerson.getName(), updatedPerson.getNusNet(), weekNumber);
 
         return new CommandResult(formattedMessage);

--- a/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
+++ b/src/main/java/seedu/address/logic/commands/util/CommandMessageUsageUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.util;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.StringUtil.areStrippedStringsEqual;
 
 /**
  * A container for {@code Command} message specific utility functions.
@@ -10,6 +11,8 @@ public class CommandMessageUsageUtil {
     public static final String EXAMPLE_LABEL = "Example: ";
 
     public static final String PARAMETER_LABEL = "Parameters: ";
+
+    public static final String CONSTRAINT_LABEL = "Constraints: ";
 
     /**
      * Generates the message usage, given the {@code commandWord}, {@code description},
@@ -35,15 +38,40 @@ public class CommandMessageUsageUtil {
     }
 
     /**
+     * Generates the message usage, given the {@code commandWord}, {@code description},
+     * {@code parameters}, {@code constraints} and {@code example} as strings.
+     */
+    public static String generateMessageUsage(String commandWord, String description,
+                                              String parameters, String constraints, String example) {
+        return commandWord + ": "
+                + description + "\n"
+                + PARAMETER_LABEL + parameters + "\n"
+                + CONSTRAINT_LABEL + constraints + "\n"
+                + EXAMPLE_LABEL + example;
+    }
+
+    /**
      * Generates the message usage, given the {@code commandWord}, {@code description} as strings,
      * and the {@code parameters}.
      */
     public static String generateMessageUsage(String commandWord, String description,
                                               Parameter... parameters) {
+        String constraints = generateMessageUsageConstraints(parameters);
+
+        if (constraints.isBlank()) {
+            return generateMessageUsage(
+                    commandWord,
+                    description,
+                    generateMessageUsageParameters(parameters),
+                    generateMessageUsageExample(commandWord, parameters)
+            );
+        }
+
         return generateMessageUsage(
                 commandWord,
                 description,
                 generateMessageUsageParameters(parameters),
+                constraints,
                 generateMessageUsageExample(commandWord, parameters)
         );
     }
@@ -58,6 +86,24 @@ public class CommandMessageUsageUtil {
             stringBuilder
                     .append(p.getFormattedParameterDetails())
                     .append(" ");
+        }
+
+        return stringBuilder.toString().trim();
+    }
+
+    /**
+     * Generates the message usage constraints, given the {@code parameters}.
+     */
+    public static String generateMessageUsageConstraints(Parameter... parameters) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (Parameter p : parameters) {
+            String constraint = p.getParameterConstraint();
+            if (!constraint.isBlank()) {
+                stringBuilder
+                        .append(constraint)
+                        .append(" ");
+            }
         }
 
         return stringBuilder.toString().trim();
@@ -86,7 +132,8 @@ public class CommandMessageUsageUtil {
      */
     public static boolean isUtilLabel(String text) {
         requireNonNull(text);
-        return EXAMPLE_LABEL.strip().equals(text.strip())
-                || PARAMETER_LABEL.strip().equals(text.strip());
+        return areStrippedStringsEqual(EXAMPLE_LABEL, text)
+                || areStrippedStringsEqual(PARAMETER_LABEL, text)
+                || areStrippedStringsEqual(CONSTRAINT_LABEL, text);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/util/Parameter.java
+++ b/src/main/java/seedu/address/logic/commands/util/Parameter.java
@@ -8,7 +8,7 @@ import java.util.Optional;
  * in a more standardized way.
  */
 public class Parameter {
-    public final String parameterHint;
+    public final String parameterConstraint;
     private final String parameterName;
     private final String[] parameterExampleValues;
 
@@ -19,14 +19,14 @@ public class Parameter {
     private final int exampleRepetitions;
 
     /**
-     * Constructor for a {@code Parameter} that takes in the {@code parameterName}, {@code parameterHint}
+     * Constructor for a {@code Parameter} that takes in the {@code parameterName}, {@code parameterConstraint}
      * and valid {@code parameterExampleValues}, with at least one example value.
      */
-    public Parameter(String parameterName, String parameterHint, String... parameterExampleValues) {
+    public Parameter(String parameterName, String parameterConstraint, String... parameterExampleValues) {
         assert parameterName != null;
         this.parameterName = parameterName;
 
-        this.parameterHint = parameterHint;
+        this.parameterConstraint = parameterConstraint;
 
         assert parameterExampleValues != null;
         assert parameterExampleValues.length > 0;
@@ -42,7 +42,7 @@ public class Parameter {
      */
     Parameter(Parameter parameter, String detailWrapper, int exampleRepetitions) {
         this.parameterName = parameter.parameterName;
-        this.parameterHint = parameter.parameterHint;
+        this.parameterConstraint = parameter.parameterConstraint;
         this.parameterExampleValues = parameter.parameterExampleValues;
 
         assert detailWrapper.contains("%s") : "detailWrapper must contain `%s`";
@@ -58,11 +58,10 @@ public class Parameter {
     }
 
     /**
-     * Gets the parameter hint or an empty string if no hint is present.
+     * Gets the parameter constraint or an empty string if no constraint is present.
      */
-    public String getParameterHint() {
-        return Optional.ofNullable(parameterHint)
-                .map(hint -> "(" + hint + ")")
+    public String getParameterConstraint() {
+        return Optional.ofNullable(parameterConstraint)
                 .orElse("");
     }
 
@@ -70,7 +69,7 @@ public class Parameter {
      * Gets the details of the parameter, which are the parameter name and hint appended behind.
      */
     public String getParameterDetails() {
-        String details = getParameterName() + " " + getParameterHint();
+        String details = getParameterName();
         return details.trim();
     }
 

--- a/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
+++ b/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
@@ -68,4 +68,10 @@ public class ParameterSyntax {
             "Course code must follow the format \"XX1234Y\", Y is optional.",
             "CS2104"
     );
+
+    public static final Parameter PARAMETER_COURSE_CODE = new Parameter(
+            "COURSE_CODE",
+            "Course code must follow the format \"XX1234Y\", Y is optional.",
+            "CS2104"
+    );
 }

--- a/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
+++ b/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
@@ -53,7 +53,7 @@ public class ParameterSyntax {
 
     public static final Parameter PARAMETER_INDEX = new Parameter(
             "INDEX",
-            "must be a positive integer",
+            "Index must be a positive integer.",
             "1"
     );
 
@@ -63,5 +63,9 @@ public class ParameterSyntax {
             "1"
     );
 
-
+    public static final Parameter PARAMETER_COURSE_CODE = new Parameter(
+            "COURSE_CODE",
+            "Course code must follow the format \"XX1234Y\", Y is optional.",
+            "CS2104"
+    );
 }

--- a/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
+++ b/src/main/java/seedu/address/logic/commands/util/ParameterSyntax.java
@@ -68,10 +68,4 @@ public class ParameterSyntax {
             "Course code must follow the format \"XX1234Y\", Y is optional.",
             "CS2104"
     );
-
-    public static final Parameter PARAMETER_COURSE_CODE = new Parameter(
-            "COURSE_CODE",
-            "Course code must follow the format \"XX1234Y\", Y is optional.",
-            "CS2104"
-    );
 }

--- a/src/main/java/seedu/address/logic/parser/SetCourseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetCourseCommandParser.java
@@ -25,7 +25,7 @@ public class SetCourseCommandParser implements Parser<SetCourseCommand> {
             course = ParserUtil.parseCourse(args);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    SetCourseCommand.MESSAGE_CONSTRAINTS), ive);
+                    SetCourseCommand.MESSAGE_USAGE), ive);
         }
 
         return new SetCourseCommand(course);

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -140,4 +140,18 @@ public class StringUtilTest {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
     }
 
+    @Test
+    void areStrippedStringsEqual_equalStrings() {
+        assertTrue(StringUtil.areStrippedStringsEqual("abc", "   abc   "));
+        assertTrue(StringUtil.areStrippedStringsEqual("   x y z   ", "x y z "));
+        assertTrue(StringUtil.areStrippedStringsEqual(null, null));
+        assertTrue(StringUtil.areStrippedStringsEqual("", "   "));
+    }
+
+    @Test
+    void areStrippedStringsEqual_unequalStrings() {
+        assertFalse(StringUtil.areStrippedStringsEqual("q w e", "qwe"));
+        assertFalse(StringUtil.areStrippedStringsEqual("   x   ", " X"));
+        assertFalse(StringUtil.areStrippedStringsEqual("", null));
+    }
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -153,5 +154,33 @@ public class StringUtilTest {
         assertFalse(StringUtil.areStrippedStringsEqual("q w e", "qwe"));
         assertFalse(StringUtil.areStrippedStringsEqual("   x   ", " X"));
         assertFalse(StringUtil.areStrippedStringsEqual("", null));
+    }
+
+    @Test
+    void stripMessageFormatSpecifiers_blankText_specifierAbsent() {
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers(""));
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers("      "));
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers("  \n "));
+    }
+
+    @Test
+    void stripMessageFormatSpecifiers_blankText_specifierPresent() {
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers("%d %s %c %f"));
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers("   %d  \n %1$d "));
+        assertEquals("", StringUtil.stripMessageFormatSpecifiers("%2$s \t %3$c  \n %1$o"));
+    }
+
+    @Test
+    void stripMessageFormatSpecifiers_nonBlankText_specifierAbsent() {
+        assertEquals("abc", StringUtil.stripMessageFormatSpecifiers("abc"));
+        assertEquals("def", StringUtil.stripMessageFormatSpecifiers("    def  "));
+        assertEquals("1 2 3", StringUtil.stripMessageFormatSpecifiers(" 1 2 3 \n"));
+    }
+
+    @Test
+    void stripMessageFormatSpecifiers_nonBlankText_specifierPresent() {
+        assertEquals("abc", StringUtil.stripMessageFormatSpecifiers("a%sb%dc"));
+        assertEquals("def", StringUtil.stripMessageFormatSpecifiers("   d%1$se%2$bf %f  "));
+        assertEquals("1 2 3", StringUtil.stripMessageFormatSpecifiers("%d\n1 2 3 %1$t \t "));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalCourse.getTypicalCourseName;
@@ -43,7 +44,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddPersonCommand(personInList), model,
-                AddPersonCommand.MESSAGE_DUPLICATE_PERSON);
+                MESSAGE_DUPLICATE_PERSON);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
@@ -57,7 +58,7 @@ public class AddCommandTest {
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
         assertThrows(CommandException.class,
-                AddPersonCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+                MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
 
         Person validPerson2 = new PersonBuilder()
             .withNusNet("E1234567")

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
@@ -117,7 +118,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditPersonCommand editCommand = new EditPersonCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
@@ -129,7 +130,7 @@ public class EditCommandTest {
         EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -71,7 +71,7 @@ public class MarkAttendanceCommandTest {
     public void execute_validNusNetDuplicateWeekNumber_markSuccess() {
         MarkAttendanceCommand command = new MarkAttendanceCommand(testValidNusNet, testValidWeekNo1);
         CommandResult expectedCommandResult =
-                new CommandResult("Re-marked Attendance for student: Alice Pauline, e0000001, Week 1");
+                new CommandResult("Attendance is already marked for student: Alice Pauline, e0000001, Week 1");
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
@@ -79,7 +79,7 @@ public class UnmarkAttendanceCommandTest {
                 ALICE.getAddress(), aliceAttendanceUpdated, ALICE.getTags());
 
         CommandResult expectedCommandResult =
-                new CommandResult("Attendance is unmarked for student: Alice Pauline, e0000001, Week 6");
+                new CommandResult("Attendance is already unmarked for student: Alice Pauline, e0000001, Week 6");
 
         UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(testValidNusNet, testValidWeekNo6);
 

--- a/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/CommandMessageUsageUtilTest.java
@@ -32,7 +32,8 @@ class CommandMessageUsageUtilTest {
         String messageUsage = CommandMessageUsageUtil
                 .generateMessageUsage("bad", "cat", p1, p2);
         assertEquals("bad: cat\n"
-                + "Parameters: ert (cbs) hic/ban\n"
+                + "Parameters: ert hic/ban\n"
+                + "Constraints: cbs\n"
                 + "Example: bad lmr hic/741",
                 messageUsage);
     }
@@ -50,7 +51,7 @@ class CommandMessageUsageUtilTest {
     @Test
     void generateMessageUsageParameters() {
         String parameters = CommandMessageUsageUtil.generateMessageUsageParameters(p1, p2);
-        assertEquals("ert (cbs) hic/ban", parameters);
+        assertEquals("ert hic/ban", parameters);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/util/ParameterTest.java
+++ b/src/test/java/seedu/address/logic/commands/util/ParameterTest.java
@@ -19,17 +19,17 @@ class ParameterTest {
 
     @Test
     void getParameterHint() {
-        assertEquals("(def)", parameter.getParameterHint());
+        assertEquals("def", parameter.getParameterConstraint());
     }
 
     @Test
     void getParameterDetails() {
-        assertEquals("abc (def)", parameter.getParameterDetails());
+        assertEquals("abc", parameter.getParameterDetails());
     }
 
     @Test
     void getFormattedParameterDetails() {
-        assertEquals("abc (def)", parameter.getParameterDetails());
+        assertEquals("abc", parameter.getParameterDetails());
     }
 
     @Test
@@ -49,26 +49,26 @@ class ParameterTest {
 
     @Test
     void asOptional_exampleNotPresent() {
-        assertEquals("[abc (def)]", parameter.asOptional(false).toString());
+        assertEquals("[abc]", parameter.asOptional(false).toString());
     }
 
     @Test
     void asOptional_examplePresent() {
-        assertEquals("[abc (def)] 123", parameter.asOptional(true).toString());
+        assertEquals("[abc] 123", parameter.asOptional(true).toString());
     }
 
     @Test
     void asMultiple_zeroExampleRepetitions() {
-        assertEquals("[abc (def)]...", parameter.asMultiple(0).toString());
+        assertEquals("[abc]...", parameter.asMultiple(0).toString());
     }
 
     @Test
     void asMultiple_oneExampleRepetitions() {
-        assertEquals("[abc (def)]... 123", parameter.asMultiple(1).toString());
+        assertEquals("[abc]... 123", parameter.asMultiple(1).toString());
     }
 
     @Test
     void asMultiple_twoExampleRepetitions() {
-        assertEquals("[abc (def)]... 123 456", parameter.asMultiple(2).toString());
+        assertEquals("[abc]... 123 456", parameter.asMultiple(2).toString());
     }
 }

--- a/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
+++ b/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
@@ -33,7 +33,7 @@ class SyntaxHighlighterTest {
         errorTextFlow = s.generateLine(Messages.MESSAGE_UNKNOWN_COMMAND);
         successTextFlow = s.generateLine(MarkAttendanceCommand.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
         genericTextFlow = s.generateLine(MarkAttendanceCommand.MESSAGE_USAGE);
-        multilineTextFlows = s.generateLines(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS + "\n"
+        multilineTextFlows = s.generateLines(MarkAttendanceCommand.MESSAGE_MARKED_ATTENDANCE_SUCCESS + "\n"
                 + MarkAttendanceCommand.MESSAGE_USAGE
         );
     }

--- a/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
+++ b/src/test/java/seedu/address/ui/util/SyntaxHighlighterTest.java
@@ -31,7 +31,7 @@ class SyntaxHighlighterTest {
     static void setUp() {
         s = new SyntaxHighlighter();
         errorTextFlow = s.generateLine(Messages.MESSAGE_UNKNOWN_COMMAND);
-        successTextFlow = s.generateLine(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
+        successTextFlow = s.generateLine(MarkAttendanceCommand.MESSAGE_MARKED_ATTENDANCE_SUCCESS);
         genericTextFlow = s.generateLine(MarkAttendanceCommand.MESSAGE_USAGE);
         multilineTextFlows = s.generateLines(Messages.MESSAGE_MARKED_ATTENDANCE_SUCCESS + "\n"
                 + MarkAttendanceCommand.MESSAGE_USAGE


### PR DESCRIPTION
## Changelog

### Visible changes
* Change person to student. Resolves #118
* Change address book to contact book.
* Use this format for NUSNet ID: `NUSNet ID`.
* Update `setcrs` message usage. Resolves #119
* `Constraints: ` will appear when there are constraints. This is better as it makes the `Parameters: ` section clearer.
* All messages will be syntax highlighted correctly (SUCCESS/NEUTRAL/ERROR). Resolves #114

### Developer changes
* New `StringUtil` class method to compare stripped strings
* Move command-specific messages to their respective classes
* Update tests
* Command Util Classes
  * Change parameter hint to parameter constraint
  * Add new label constraint
  * Add `NEUTRAL_MESSAGES`

## UI Changes
>[!NOTE]
>`setcrs`
>
>![Screenshot 2024-03-31 141639](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/860c8805-4022-4e80-a587-5d7aea0ea8ee)

>[!NOTE]
>`edit`
>
>![Screenshot 2024-03-31 141631](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/68f49826-1e18-4c63-978b-0aa00a22b52f)


