### PR TITLE
feat: Autocomplete result TAB scrolling

### DIFF
--- a/src/main/java/seedu/address/commons/util/Trie.java
+++ b/src/main/java/seedu/address/commons/util/Trie.java
@@ -113,8 +113,6 @@ public class Trie {
             sb.append(c);
             current = current.getChild(c);
         }
-        System.out.println(prefix);
-        System.out.println(findAllWordsWithPrefix(prefix));
 
         return findFirstWordWithPrefixHelper(current, sb);
     }

--- a/src/main/java/seedu/address/commons/util/Trie.java
+++ b/src/main/java/seedu/address/commons/util/Trie.java
@@ -1,5 +1,8 @@
 package seedu.address.commons.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A class that represents a Trie data structure.
  */
@@ -110,6 +113,9 @@ public class Trie {
             sb.append(c);
             current = current.getChild(c);
         }
+        System.out.println(prefix);
+        System.out.println(findAllWordsWithPrefix(prefix));
+
         return findFirstWordWithPrefixHelper(current, sb);
     }
 
@@ -122,5 +128,46 @@ public class Trie {
             return findFirstWordWithPrefixHelper(current.getChild(c), sb);
         }
         return "";
+    }
+
+    /**
+     * Finds all words in the Trie that starts with the given prefix.
+     *
+     * @param prefix the prefix to be searched
+     * @return list of all words that starts with the given prefix. If no such words exist, return empty list.
+     * @see #findFirstWordWithPrefixHelper(TrieNode, StringBuilder)
+     * @see #findAllWordsWithPrefix(String)
+     */
+    public List<String> findAllWordsWithPrefix(String prefix) {
+        TrieNode current = root;
+        StringBuilder sb = new StringBuilder();
+        for (char c : prefix.toCharArray()) {
+            if (current.getChild(c) == null) {
+                return List.of();
+            }
+            sb.append(c);
+            current = current.getChild(c);
+        }
+        return allWordsWithPrefixHelper(current, sb);
+    }
+
+    /**
+     * Finds all words valid nodes of the {@code current} TrieNode recursively.
+     *
+     * @see #findAllWordsWithPrefix(String)
+     */
+    private List<String> allWordsWithPrefixHelper(TrieNode current, StringBuilder sb) {
+        List<String> allWords = new ArrayList<>();
+        if (current.isEndOfWord()) {
+            allWords.add(sb.toString());
+        }
+        for (char c : current.getChildren().keySet()) {
+            // Use new copy of sb
+            allWords.addAll(allWordsWithPrefixHelper(
+                    current.getChild(c),
+                    new StringBuilder(sb.toString() + c)
+            ));
+        }
+        return allWords;
     }
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.autocomplete.AutoCompleteResult;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -26,13 +27,12 @@ public interface Logic {
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
     /**
-     * Returns the autocomplete text based on the input.
+     * Returns the autocomplete results based on the input.
      *
      * @param commandText The input as entered by the user.
-     * @return the autocomplete text to be appended to the input.
-     * @see seedu.address.logic.autocomplete.AutoComplete#getAutoComplete(String)
+     * @return the autocomplete results to be appended to the input.
      */
-    String autoComplete(String commandText);
+    AutoCompleteResult autoComplete(String commandText);
 
     /**
      * Returns the AddressBook.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.autocomplete.AutoComplete;
 import seedu.address.logic.autocomplete.AutoCompleteCommand;
 import seedu.address.logic.autocomplete.AutoCompleteNusNetId;
+import seedu.address.logic.autocomplete.AutoCompleteResult;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -84,7 +85,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public String autoComplete(String commandText) {
+    public AutoCompleteResult autoComplete(String commandText) {
         AutoComplete ac = addressBookParser.parseAutoComplete(commandText);
         assert ac != null;
         return ac.getAutoComplete(commandText);

--- a/src/main/java/seedu/address/logic/autocomplete/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoComplete.java
@@ -5,10 +5,10 @@ package seedu.address.logic.autocomplete;
  */
 public interface AutoComplete {
     /**
-     * Returns the autocomplete text based on the input.
+     * Returns the autocomplete result based on the input.
      *
      * @param input The input as entered by the user.
-     * @return the autocomplete text to be appended to the input.
+     * @return the autocomplete result to be appended to the input.
      */
-    String getAutoComplete(String input);
+    AutoCompleteResult getAutoComplete(String input);
 }

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteCommand.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteCommand.java
@@ -3,6 +3,9 @@ package seedu.address.logic.autocomplete;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.commands.util.CommandWordUtil.getAllCommandWords;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import seedu.address.commons.util.Trie;
 
 /**
@@ -22,16 +25,21 @@ public class AutoCompleteCommand implements AutoComplete {
     }
 
     @Override
-    public String getAutoComplete(String input) {
+    public AutoCompleteResult getAutoComplete(String input) {
         requireNonNull(commandTrie);
-        String fullCommand = commandTrie.findFirstWordWithPrefix(input);
+        List<String> fullCommands = commandTrie.findAllWordsWithPrefix(input);
 
-        assert fullCommand != null;
-        if (fullCommand.isEmpty()) {
-            return "";
+        assert fullCommands != null;
+        if (fullCommands.isEmpty()) {
+            return new AutoCompleteResult();
         }
 
-        // Strip the input from the full command
-        return fullCommand.substring(input.length());
+        // Strip the input from the full commands and sort the list
+        return new AutoCompleteResult(
+                fullCommands.stream()
+                        .map(c -> c.substring(input.length()))
+                        .sorted()
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteNusNetId.java
@@ -3,8 +3,10 @@ package seedu.address.logic.autocomplete;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NUSNET;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.Trie;
 
@@ -36,7 +38,7 @@ public class AutoCompleteNusNetId implements AutoComplete {
     }
 
     @Override
-    public String getAutoComplete(String input) {
+    public AutoCompleteResult getAutoComplete(String input) {
         assert nusNetIdTrie != null;
 
         Matcher m = NUSNET_ID_FORMAT.matcher(input);
@@ -44,14 +46,19 @@ public class AutoCompleteNusNetId implements AutoComplete {
         assert isNusNetId;
 
         String partialNusNetId = m.group(1);
-        String fullNusNetId = nusNetIdTrie.findFirstWordWithPrefix(partialNusNetId.toUpperCase());
+        List<String> fullNusNetIds = nusNetIdTrie.findAllWordsWithPrefix(partialNusNetId.toUpperCase());
 
-        assert fullNusNetId != null;
-        if (fullNusNetId.isEmpty()) {
-            return "";
+        assert fullNusNetIds != null;
+        if (fullNusNetIds.isEmpty()) {
+            return new AutoCompleteResult();
         }
 
-        // Strip the input from the full command
-        return fullNusNetId.substring(partialNusNetId.length());
+        // Strip the input from the full commands and sort the list
+        return new AutoCompleteResult(
+                fullNusNetIds.stream()
+                    .map(c -> c.substring(partialNusNetId.length()))
+                    .sorted()
+                    .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteResult.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteResult.java
@@ -4,6 +4,10 @@ import java.util.List;
 
 /**
  * Stores the result of running the {@link AutoCompleteCommand}.
+ * <p>
+ * The result is an empty string if there is no result.
+ * <p>
+ * The result are the rest of the possible strings after the prefix if results exist.
  */
 public class AutoCompleteResult {
     final List<String> results;
@@ -16,7 +20,6 @@ public class AutoCompleteResult {
      */
     public AutoCompleteResult(List<String> results) {
         this.results = results;
-        System.out.println(results);
         currentIndex = 0;
     }
 

--- a/src/main/java/seedu/address/logic/autocomplete/AutoCompleteResult.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutoCompleteResult.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.autocomplete;
+
+import java.util.List;
+
+/**
+ * Stores the result of running the {@link AutoCompleteCommand}.
+ */
+public class AutoCompleteResult {
+    final List<String> results;
+
+    /** The internal pointer to the current result */
+    private int currentIndex;
+
+    /**
+     * Creates an autocomplete result given a results list.
+     */
+    public AutoCompleteResult(List<String> results) {
+        this.results = results;
+        System.out.println(results);
+        currentIndex = 0;
+    }
+
+    /**
+     * Creates an autocomplete result that doesn't have a result.
+     */
+    public AutoCompleteResult() {
+        results = List.of();
+        currentIndex = 0;
+    }
+
+    /**
+     * Gets the next result in from the circular results list
+     * and increments an internal pointer to the next result,
+     * if there is a result.
+     */
+    public String getNextResult() {
+        assert results != null;
+
+        if (results.isEmpty()) {
+            return "";
+        }
+
+        String currentResult = results.get(currentIndex);
+        currentIndex = (currentIndex + 1) % results.size();
+
+        if (currentResult == null) {
+            return "";
+        }
+
+        return currentResult;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.autocomplete.AutoComplete;
 import seedu.address.logic.autocomplete.AutoCompleteCommand;
 import seedu.address.logic.autocomplete.AutoCompleteNusNetId;
+import seedu.address.logic.autocomplete.AutoCompleteResult;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -110,7 +111,7 @@ public class AddressBookParser {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             logger.finer("Unable to parse user input for autocomplete: " + userInput);
-            return input -> "";
+            return input -> new AutoCompleteResult();
         }
 
         final String arguments = matcher.group(ARGUMENTS_GROUP);
@@ -124,6 +125,6 @@ public class AddressBookParser {
             return new AutoCompleteNusNetId();
         }
 
-        return input -> "";
+        return input -> new AutoCompleteResult();
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.logic.Logic;
+import seedu.address.logic.autocomplete.AutoCompleteResult;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -263,7 +264,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Auto completes the command and returns the text to append to the input.
      */
-    private String autoComplete(String commandText) {
+    private AutoCompleteResult autoComplete(String commandText) {
         return logic.autoComplete(commandText);
     }
 }

--- a/src/test/java/seedu/address/commons/util/TrieTest.java
+++ b/src/test/java/seedu/address/commons/util/TrieTest.java
@@ -108,4 +108,31 @@ class TrieTest {
         assertEquals("", trie.findFirstWordWithPrefix("a"));
         assertEquals("", trie.findFirstWordWithPrefix("ab"));
     }
+
+    @Test
+    void findAllWordsWithPrefix() {
+        Trie trie = new Trie(
+                "hello",
+                "world",
+                "hell",
+                "word",
+                "work",
+                "wording"
+        );
+
+        assertEquals(2, trie.findAllWordsWithPrefix("he").size());
+        assertEquals("hell", trie.findAllWordsWithPrefix("he").get(0));
+        assertEquals("hello", trie.findAllWordsWithPrefix("he").get(1));
+
+        assertEquals(4, trie.findAllWordsWithPrefix("w").size());
+        assertEquals("word", trie.findAllWordsWithPrefix("w").get(0));
+        assertEquals("wording", trie.findAllWordsWithPrefix("w").get(1));
+        assertEquals("work", trie.findAllWordsWithPrefix("w").get(2));
+        assertEquals("world", trie.findAllWordsWithPrefix("w").get(3));
+
+        assertEquals(1, trie.findAllWordsWithPrefix("hello").size());
+        assertEquals("hello", trie.findAllWordsWithPrefix("hello").get(0));
+
+        assertEquals(0, trie.findAllWordsWithPrefix("x").size());
+    }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -200,12 +200,12 @@ public class LogicManagerTest {
         String prefix = fullAddPersonCommand.substring(0, 2);
         String remaining = fullAddPersonCommand.substring(2);
 
-        assertEquals(remaining, logic.autoComplete(prefix));
+        assertEquals(remaining, logic.autoComplete(prefix).getNextResult());
 
         String fullListPersonCommand = ListPersonCommand.COMMAND_WORD;
         prefix = fullListPersonCommand.substring(0, 2);
         remaining = fullListPersonCommand.substring(2);
 
-        assertEquals(remaining, logic.autoComplete(prefix));
+        assertEquals(remaining, logic.autoComplete(prefix).getNextResult());
     }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteCommandTest.java
@@ -15,9 +15,9 @@ class AutoCompleteCommandTest {
 
         AutoComplete autoComplete = new AutoCompleteCommand();
         // Test for a command that is not in the trie
-        assertEquals("", autoComplete.getAutoComplete("xdddd"));
+        assertEquals("", autoComplete.getAutoComplete("xdddd").getNextResult());
 
         // Test for a command that is in the trie
-        assertEquals("it", autoComplete.getAutoComplete("ed"));
+        assertEquals("it", autoComplete.getAutoComplete("ed").getNextResult());
     }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteNusNetIdTest.java
@@ -16,9 +16,9 @@ class AutoCompleteNusNetIdTest {
 
         AutoComplete ac = new AutoCompleteNusNetId();
 
-        assertEquals("234567", ac.getAutoComplete("nn/e1"));
-        assertEquals("654321", ac.getAutoComplete("nn/e7"));
-        assertEquals("000000", ac.getAutoComplete("nn/e0"));
+        assertEquals("234567", ac.getAutoComplete("nn/e1").getNextResult());
+        assertEquals("654321", ac.getAutoComplete("nn/e7").getNextResult());
+        assertEquals("000000", ac.getAutoComplete("nn/e0").getNextResult());
 
         AutoCompleteNusNetId.update(
               "e1111111",
@@ -26,12 +26,12 @@ class AutoCompleteNusNetIdTest {
               "e3333333"
         );
 
-        assertEquals("111111", ac.getAutoComplete("nn/e1"));
-        assertEquals("222222", ac.getAutoComplete("nn/e2"));
-        assertEquals("333333", ac.getAutoComplete("nn/e3"));
+        assertEquals("111111", ac.getAutoComplete("nn/e1").getNextResult());
+        assertEquals("222222", ac.getAutoComplete("nn/e2").getNextResult());
+        assertEquals("333333", ac.getAutoComplete("nn/e3").getNextResult());
 
         AutoCompleteNusNetId.update(); // Clear all NUSNET IDs
 
-        assertEquals("", ac.getAutoComplete("nn/e1"));
+        assertEquals("", ac.getAutoComplete("nn/e1").getNextResult());
     }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/AutoCompleteResultTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutoCompleteResultTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.autocomplete;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class AutoCompleteResultTest {
+
+    @Test
+    void getNextResult() {
+        AutoCompleteResult result = new AutoCompleteResult(Arrays.asList("abc", "def", "", "123", null));
+        assertEquals("abc", result.getNextResult());
+        assertEquals("def", result.getNextResult());
+        assertEquals("", result.getNextResult());
+        assertEquals("123", result.getNextResult());
+        assertEquals("", result.getNextResult());
+        assertEquals("abc", result.getNextResult());
+    }
+
+    @Test
+    void getNextResult_emptyResult() {
+        AutoCompleteResult result = new AutoCompleteResult();
+        assertEquals("", result.getNextResult());
+        assertEquals("", result.getNextResult());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -148,14 +148,14 @@ public class AddressBookParserTest {
     void parseAutoComplete() {
         // No input
         AutoComplete ac = parser.parseAutoComplete("");
-        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+        assertEquals(ac.getAutoComplete("arbitrary_input").getNextResult(), "");
 
         // Test for input that contains only command word and no arguments
         assert(parser.parseAutoComplete("arbitrary_command") instanceof AutoCompleteCommand);
 
         // Test for input that contains command word and arguments
         ac = parser.parseAutoComplete("arbitrary_command arbitrary_arguments");
-        assertEquals(ac.getAutoComplete("arbitrary_input"), "");
+        assertEquals(ac.getAutoComplete("arbitrary_input").getNextResult(), "");
 
         // Test for input that contains NUSNET ID
         ac = parser.parseAutoComplete("arbitrary_command nn/arbitrary_nusnet_id");


### PR DESCRIPTION
Adds TAB scrolling through autocomplete result.

**Example 1**
Pressing TAB repeatedly: `mark nn/` should go through the all NUSNet IDs.

**Example 2**
Press TAB repeatedly: `mark nn/e1` should go through the all NUSNet IDs starting with `e1`.

Resolves #115 