### PR TITLE
bug: Add duplicate prefix check for mark and unmark command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
@@ -28,7 +28,10 @@ public class MarkAttendanceCommandParser implements Parser<MarkAttendanceCommand
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     MarkAttendanceCommand.MESSAGE_USAGE));
         }
-
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NUSNET,
+                PREFIX_WEEK
+        );
         NusNet nusNet = ParserUtil.parseNusNet(argMultimap.getValue(PREFIX_NUSNET).get());
         WeekNumber weekNumber = ParserUtil.parseWeekNumber(argMultimap.getValue(PREFIX_WEEK).get());
 

--- a/src/main/java/seedu/address/logic/parser/UnmarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkAttendanceCommandParser.java
@@ -29,7 +29,10 @@ public class UnmarkAttendanceCommandParser implements Parser<UnmarkAttendanceCom
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UnmarkAttendanceCommand.MESSAGE_USAGE));
         }
-
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NUSNET,
+                PREFIX_WEEK
+        );
         NusNet nusNet = ParserUtil.parseNusNet(argMultimap.getValue(PREFIX_NUSNET).get());
         WeekNumber weekNumber = ParserUtil.parseWeekNumber(argMultimap.getValue(PREFIX_WEEK).get());
 


### PR DESCRIPTION
Resolves #173 and #174 