### PR TITLE
docs: Fix CommandHistoryDiagramColor

### DIFF
--- a/docs/diagrams/CommandHistorySequenceDiagram.puml
+++ b/docs/diagrams/CommandHistorySequenceDiagram.puml
@@ -2,9 +2,9 @@
 !include style.puml
 skinparam ArrowFontStyle plain
 
-box Command History UI_COLOR_T2
-participant ":CommandBox" as Model UI_COLOR_T3
-participant ":CommandHistory" as ModelCH UI_COLOR_T3
+box Command History UI_COLOR_T1
+participant ":CommandBox" as Model UI_COLOR
+participant ":CommandHistory" as ModelCH UI_COLOR
 end box
 
 [-> Model : keyPress(e)

--- a/docs/diagrams/CommandHistorySequenceDiagram.puml
+++ b/docs/diagrams/CommandHistorySequenceDiagram.puml
@@ -2,7 +2,7 @@
 !include style.puml
 skinparam ArrowFontStyle plain
 
-box Command History UI_COLOR_T1
+box UI UI_COLOR_T1
 participant ":CommandBox" as Model UI_COLOR
 participant ":CommandHistory" as ModelCH UI_COLOR
 end box


### PR DESCRIPTION
This is so that we don't hinder readability. Also note that there is another bug I haven't fixed, it should be UI and not CommandHistory for the heading. (now is fixed)

![image](https://github.com/AY2324S2-CS2103T-F13-1/tp/assets/39845485/275baa38-6a58-4b7d-8cfa-193f82961c94)
